### PR TITLE
fix: card_mod compatibility and localize empty state message

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -50,7 +50,8 @@
   },
   "ui": {
     "show_more": "Zeige {n} weitere",
-    "show_less": "Weniger anzeigen"
+    "show_less": "Weniger anzeigen",
+    "no_events": "Keine Ereignisse in diesem Zeitraum."
   },
   "date_format": {
     "datetime": {

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -50,7 +50,8 @@
   },
   "ui": {
     "show_more": "Show {n} more",
-    "show_less": "Show less"
+    "show_less": "Show less",
+    "no_events": "No events in this time period."
   },
   "date_format": {
     "datetime": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -50,7 +50,8 @@
   },
   "ui": {
     "show_more": "Show {n} more",
-    "show_less": "Show less"
+    "show_less": "Show less",
+    "no_events": "No events in this time period."
   },
   "date_format": {
     "datetime": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -50,7 +50,8 @@
   },
   "ui": {
     "show_more": "Afficher {n} de plus",
-    "show_less": "Afficher moins"
+    "show_less": "Afficher moins",
+    "no_events": "Aucun événement dans cette période."
   },
   "date_format": {
     "datetime": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -50,7 +50,8 @@
   },
   "ui": {
     "show_more": "Mostrar mais {n}",
-    "show_less": "Mostrar menos"
+    "show_less": "Mostrar menos",
+    "no_events": "Nenhum evento neste período."
   },
   "date_format": {
     "datetime": {

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -136,6 +136,28 @@ class TimelineCard extends HTMLElement {
     this.config = config;
   }
 
+  connectedCallback() {
+    // Ensure structure exists immediately so card_mod can attach
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: "open" });
+    }
+    this.ensureCardExists();
+  }
+
+  ensureCardExists() {
+    console.log("test");
+    const root = this.shadowRoot;
+    if (!root.querySelector('style')) {
+        const styleEl = document.createElement('style');
+        styleEl.textContent = styles;
+        root.appendChild(styleEl);
+    }
+    if (!root.querySelector("ha-card")) {
+        const card = document.createElement("ha-card");
+        root.appendChild(card);
+    }
+  }
+
   set hass(hass) {
     this.hassInst = hass;
 
@@ -330,14 +352,21 @@ class TimelineCard extends HTMLElement {
   // RENDER CARD
   // ------------------------------------
   render() {
-    const root = this.shadowRoot || this.attachShadow({ mode: "open" });
+    // Check if we already have a shadow root
+    let root = this.shadowRoot;
+    
+    // If not, create it
+    if (!root) {
+      root = this.attachShadow({ mode: "open" });
+    }
+
+    // Ensure card exists
+    this.ensureCardExists();
+    let card = root.querySelector("ha-card");
 
     if (!this.items.length) {
-      root.innerHTML = `
-        <style>${styles}</style>
-        <ha-card>
-          <div style="padding:12px">Keine Ereignisse in diesem Zeitraum.</div>
-        </ha-card>
+      card.innerHTML = `
+          <div style="padding:12px">${this.i18n.t("ui.no_events")}</div>
       `;
       return;
     }
@@ -486,9 +515,7 @@ class TimelineCard extends HTMLElement {
         `
         : "";
 
-    root.innerHTML = `
-      <style>${styles}</style>
-      <ha-card>
+    card.innerHTML = `
         ${this.title ? `<h1 class="card-title">${this.title}</h1>` : ""}
         <div class="timeline-container ${
           overflowMode === "scroll" ? "scrollable" : ""
@@ -499,7 +526,6 @@ class TimelineCard extends HTMLElement {
           </div>
         </div>
         ${collapseToggle}
-      </ha-card>
     `;
 
     const toggleBtn = root.getElementById("tc-toggle-hidden");


### PR DESCRIPTION
- Reuse existing `ha-card` element during render to preserve card_mod styles
- Ensure `ha-card` is created in `connectedCallback` for early style attachment
- Add `no_events` translation key to all supported locales
- Replace hardcoded "Keine Ereignisse..." string with localized value, closes #24

Tested the changes locally by running `npm run build`, copying the resulting JavaScript, and loading the newly built JavaScript instead of the HACS version. After that, I was able to apply a custom card_mod style to the card and make it work on page load (before it only worked after editing the card).

<img width="442" height="253" alt="image" src="https://github.com/user-attachments/assets/5f30e8d2-7323-489f-9b6f-f4884494f6e4" />

I created some test messages and applied the following card_mod style:
```yaml
card_mod:
  style: |
    .primary-text.state {
      text-overflow: unset !important;
      overflow: auto !important;
      white-space: normal !important;
      color: red;
    }
```

Localized no events message:
<img width="478" height="70" alt="image" src="https://github.com/user-attachments/assets/69b35829-7f9c-4c5a-965b-cc50df13e7e9" />
