### PR TITLE
add Russian localization and migrate configurator selectors for new Home Assistant UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Timeline Card
+# Timeline Card
 
 [![HACS Default](https://img.shields.io/badge/HACS-Default-blue?style=flat&logo=homeassistantcommunitystore&logoSize=auto)](https://my.home-assistant.io/redirect/hacs_repository/?owner=weedpump&repository=timeline-card&category=plugin)
 [![HACS Validate](https://github.com/weedpump/timeline-card/actions/workflows/validate.yaml/badge.svg)](https://github.com/weedpump/timeline-card/actions/workflows/validate.yaml)
@@ -166,7 +166,7 @@ entities:
 | `show_names`           | boolean | no       | true     | Show entity names                                                                                              |
 | `show_states`          | boolean | no       | true     | Show entity states                                                                                             |
 | `show_icons`           | boolean | no       | true     | Show entity icons                                                                                              |
-| `language`             | string  | no       | auto     | Language code (default `en-US`; supports `en-US`, `en-GB`, `de`, `fr`, `pt-BR`, etc.)                          |
+| `language`             | string  | no       | auto     | Language code (default `en-US`; supports `en-US`, `en-GB`, `de`, `fr`, `it`, `pt-BR`, `ru`, `sv`, etc.)        |
 | `refresh_interval`     | number  | no       | -        | Auto-refresh interval in seconds (background refresh)                                                          |
 | `allow_multiline`      | boolean | no       | false    | Enables automatic multiline wrapping for long names/states                                                     |
 | `force_multiline`      | boolean | no       | false    | Always place the state on a new line below the name                                                            |
@@ -396,7 +396,9 @@ Available translations:
 - English
 - German
 - French
+- Italian
 - Brazilian Portuguese
+- Russian
 - Swedish
 
 ---

--- a/src/editor/entity-editor.js
+++ b/src/editor/entity-editor.js
@@ -23,7 +23,7 @@ class TimelineCardEntityEditor extends LitElement {
           ${editorStyles}
         </style>
         <div class="tc-editor-root">
-          <div class="tc-placeholder">Сущность не выбрана.</div>
+          <div class="tc-placeholder">No entity selected.</div>
         </div>
       `;
     }
@@ -57,7 +57,7 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-editor-root">
         <!-- OVERVIEW -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Обзор сущности</h3>
+          <h3 class="tc-section-title">Entity overview</h3>
 
           <div
             class="tc-card-block"
@@ -78,14 +78,14 @@ class TimelineCardEntityEditor extends LitElement {
 
         <!-- DISPLAY -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Отображение</h3>
+          <h3 class="tc-section-title">Display</h3>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- CUSTOM NAME -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Пользовательское имя</div>
+                  <div class="tc-setting-title">Custom name</div>
                 </div>
 
                 <ha-textfield
@@ -98,7 +98,7 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- CUSTOM ICON -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Пользовательская иконка</div>
+                  <div class="tc-setting-title">Custom icon</div>
                 </div>
 
                 <ha-icon-picker
@@ -110,8 +110,8 @@ class TimelineCardEntityEditor extends LitElement {
               </div>
 
               ${this._booleanRow(
-                'Использовать изображение сущности (если есть)',
-                'Показывать изображение сущности вместо иконки, если оно задано.',
+                'Use entity picture (if available)',
+                'Show the entity picture instead of the icon when provided.',
                 'show_entity_picture',
                 cfg.show_entity_picture ?? null
               )}
@@ -119,38 +119,38 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- COLORS -->
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Цвета</div>
+                  <div class="tc-setting-title">Colors</div>
                   <div class="tc-setting-description">
-                    Необязательные статические цвета для иконки, имени и состояния.
+                    Optional static colors for icon, name and state.
                   </div>
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'icon_color',
                     cfg.icon_color,
-                    'Цвет иконки'
+                    'Icon color'
                   )}
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'name_color',
                     cfg.name_color,
-                    'Цвет имени'
+                    'Name color'
                   )}
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'state_color',
                     cfg.state_color,
-                    'Цвет состояния'
+                    'State color'
                   )}
                 </div>
               </div>
 
               <!-- COLLAPSE DUPLICATES -->
               ${this._booleanRow(
-                'Скрывать дубликаты (уровень сущности)',
-                'Скрывать последовательные одинаковые состояния для этой сущности.',
+                'Collapse duplicates (entity level)',
+                'Hide consecutive identical states for this entity.',
                 'collapse_duplicates',
                 cfg.collapse_duplicates ?? null
               )}
@@ -158,9 +158,9 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- INCLUDE STATES (YAML ONLY) -->
               <div class="tc-setting-row" style="align-items: flex-start;">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Включать состояния</div>
+                  <div class="tc-setting-title">Include states</div>
                   <div class="tc-setting-description">
-                    Показывать только события из этого YAML-списка:
+                    Only show events matching this YAML list:
                     <pre>
 - open
 - closed
@@ -196,9 +196,9 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- EXCLUDE STATES (YAML ONLY) -->
               <div class="tc-setting-row" style="align-items: flex-start;">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Исключать состояния</div>
+                  <div class="tc-setting-title">Exclude states</div>
                   <div class="tc-setting-description">
-                    Скрывать события из этого YAML-списка:
+                    Hide events matching this YAML list:
                     <pre>
 - idle
 - unknown
@@ -236,24 +236,24 @@ class TimelineCardEntityEditor extends LitElement {
 
         <!-- COLORS -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Сопоставление состояний</h3>
+          <h3 class="tc-section-title">State mapping</h3>
           <div class="tc-card-block">
             <div class="tc-form-group">
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Карта подписей состояний</div>
+                  <div class="tc-setting-title">State label map</div>
                   <div class="tc-setting-description">
-                    Переопределение отображаемых подписей для raw-состояний.
+                    Override displayed labels per raw state.
                   </div>
                 </div>
-                ${this._renderMapEditor('state_map', cfg.state_map, 'Подпись')}
+                ${this._renderMapEditor('state_map', cfg.state_map, 'Label')}
               </div>
 
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Карта иконок</div>
+                  <div class="tc-setting-title">Icon map</div>
                   <div class="tc-setting-description">
-                    Иконки для каждого состояния (имена MDI).
+                    Select icons per state (uses MDI names).
                   </div>
                 </div>
                 ${this._renderIconMapEditor('icon_map', cfg.icon_map)}
@@ -261,9 +261,9 @@ class TimelineCardEntityEditor extends LitElement {
 
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Карта цветов иконок</div>
+                  <div class="tc-setting-title">Icon color map</div>
                   <div class="tc-setting-description">
-                    Цвет Hex/RGB для каждого состояния.
+                    Hex/RGB color per state.
                   </div>
                 </div>
                 ${this._renderColorMapEditor(
@@ -363,21 +363,21 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              Пока нет записей.
+              No entries yet.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row tc-map-row-icon">
                   <ha-textfield
                     class="tc-map-key"
-                    label="Состояние"
+                    label="State"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
                   ></ha-textfield>
                   <ha-textfield
                     class="tc-map-value"
-                    label="Значение"
+                    label="Value"
                     .value=${value}
                     placeholder=${placeholder}
                     @input=${(e) =>
@@ -385,7 +385,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ></ha-textfield>
                   <button
                     class="tc-icon-button"
-                    title="Удалить запись"
+                    title="Remove entry"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -399,7 +399,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Добавить запись
+          Add entry
         </button>
       </div>
     `;
@@ -419,14 +419,14 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              Пока нет записей.
+              No entries yet.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row">
                   <ha-textfield
                     class="tc-map-key"
-                    label="Состояние"
+                    label="State"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
@@ -439,7 +439,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ></ha-icon-picker>
                   <button
                     class="tc-icon-button"
-                    title="Удалить запись"
+                    title="Remove entry"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -453,7 +453,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Добавить запись
+          Add entry
         </button>
       </div>
     `;
@@ -466,14 +466,14 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              Пока нет записей.
+              No entries yet.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row tc-map-row-color">
                   <ha-textfield
                     class="tc-map-key"
-                    label="Состояние"
+                    label="State"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
@@ -481,7 +481,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ${this._renderMapColorPicker(mapKey, state, value)}
                   <button
                     class="tc-icon-button"
-                    title="Удалить запись"
+                    title="Remove entry"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -495,7 +495,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Добавить запись
+          Add entry
         </button>
       </div>
     `;
@@ -564,7 +564,7 @@ class TimelineCardEntityEditor extends LitElement {
           />
           <button
             class="tc-icon-button"
-            title="Сбросить цвет"
+            title="Clear color"
             @click=${() => this._updateField(key, undefined)}
           >
             <ha-icon icon="mdi:close"></ha-icon>

--- a/src/editor/entity-editor.js
+++ b/src/editor/entity-editor.js
@@ -23,7 +23,7 @@ class TimelineCardEntityEditor extends LitElement {
           ${editorStyles}
         </style>
         <div class="tc-editor-root">
-          <div class="tc-placeholder">No entity selected.</div>
+          <div class="tc-placeholder">Сущность не выбрана.</div>
         </div>
       `;
     }
@@ -57,7 +57,7 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-editor-root">
         <!-- OVERVIEW -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Entity overview</h3>
+          <h3 class="tc-section-title">Обзор сущности</h3>
 
           <div
             class="tc-card-block"
@@ -78,14 +78,14 @@ class TimelineCardEntityEditor extends LitElement {
 
         <!-- DISPLAY -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Display</h3>
+          <h3 class="tc-section-title">Отображение</h3>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- CUSTOM NAME -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Custom name</div>
+                  <div class="tc-setting-title">Пользовательское имя</div>
                 </div>
 
                 <ha-textfield
@@ -98,7 +98,7 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- CUSTOM ICON -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Custom icon</div>
+                  <div class="tc-setting-title">Пользовательская иконка</div>
                 </div>
 
                 <ha-icon-picker
@@ -110,8 +110,8 @@ class TimelineCardEntityEditor extends LitElement {
               </div>
 
               ${this._booleanRow(
-                'Use entity picture (if available)',
-                'Show the entity picture instead of the icon when provided.',
+                'Использовать изображение сущности (если есть)',
+                'Показывать изображение сущности вместо иконки, если оно задано.',
                 'show_entity_picture',
                 cfg.show_entity_picture ?? null
               )}
@@ -119,38 +119,38 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- COLORS -->
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Colors</div>
+                  <div class="tc-setting-title">Цвета</div>
                   <div class="tc-setting-description">
-                    Optional static colors for icon, name and state.
+                    Необязательные статические цвета для иконки, имени и состояния.
                   </div>
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'icon_color',
                     cfg.icon_color,
-                    'Icon color'
+                    'Цвет иконки'
                   )}
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'name_color',
                     cfg.name_color,
-                    'Name color'
+                    'Цвет имени'
                   )}
                 </div>
                 <div class="tc-color-row">
                   ${this._renderColorPicker(
                     'state_color',
                     cfg.state_color,
-                    'State color'
+                    'Цвет состояния'
                   )}
                 </div>
               </div>
 
               <!-- COLLAPSE DUPLICATES -->
               ${this._booleanRow(
-                'Collapse duplicates (entity level)',
-                'Hide consecutive identical states for this entity.',
+                'Скрывать дубликаты (уровень сущности)',
+                'Скрывать последовательные одинаковые состояния для этой сущности.',
                 'collapse_duplicates',
                 cfg.collapse_duplicates ?? null
               )}
@@ -158,9 +158,9 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- INCLUDE STATES (YAML ONLY) -->
               <div class="tc-setting-row" style="align-items: flex-start;">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Include states</div>
+                  <div class="tc-setting-title">Включать состояния</div>
                   <div class="tc-setting-description">
-                    Only show events matching this YAML list:
+                    Показывать только события из этого YAML-списка:
                     <pre>
 - open
 - closed
@@ -196,9 +196,9 @@ class TimelineCardEntityEditor extends LitElement {
               <!-- EXCLUDE STATES (YAML ONLY) -->
               <div class="tc-setting-row" style="align-items: flex-start;">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Exclude states</div>
+                  <div class="tc-setting-title">Исключать состояния</div>
                   <div class="tc-setting-description">
-                    Hide events matching this YAML list:
+                    Скрывать события из этого YAML-списка:
                     <pre>
 - idle
 - unknown
@@ -236,24 +236,24 @@ class TimelineCardEntityEditor extends LitElement {
 
         <!-- COLORS -->
         <div class="tc-section">
-          <h3 class="tc-section-title">State mapping</h3>
+          <h3 class="tc-section-title">Сопоставление состояний</h3>
           <div class="tc-card-block">
             <div class="tc-form-group">
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">State label map</div>
+                  <div class="tc-setting-title">Карта подписей состояний</div>
                   <div class="tc-setting-description">
-                    Override displayed labels per raw state.
+                    Переопределение отображаемых подписей для raw-состояний.
                   </div>
                 </div>
-                ${this._renderMapEditor('state_map', cfg.state_map, 'Label')}
+                ${this._renderMapEditor('state_map', cfg.state_map, 'Подпись')}
               </div>
 
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Icon map</div>
+                  <div class="tc-setting-title">Карта иконок</div>
                   <div class="tc-setting-description">
-                    Select icons per state (uses MDI names).
+                    Иконки для каждого состояния (имена MDI).
                   </div>
                 </div>
                 ${this._renderIconMapEditor('icon_map', cfg.icon_map)}
@@ -261,9 +261,9 @@ class TimelineCardEntityEditor extends LitElement {
 
               <div class="tc-setting-block">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Icon color map</div>
+                  <div class="tc-setting-title">Карта цветов иконок</div>
                   <div class="tc-setting-description">
-                    Hex/RGB color per state.
+                    Цвет Hex/RGB для каждого состояния.
                   </div>
                 </div>
                 ${this._renderColorMapEditor(
@@ -363,21 +363,21 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              No entries yet.
+              Пока нет записей.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row tc-map-row-icon">
                   <ha-textfield
                     class="tc-map-key"
-                    label="State"
+                    label="Состояние"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
                   ></ha-textfield>
                   <ha-textfield
                     class="tc-map-value"
-                    label="Value"
+                    label="Значение"
                     .value=${value}
                     placeholder=${placeholder}
                     @input=${(e) =>
@@ -385,7 +385,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ></ha-textfield>
                   <button
                     class="tc-icon-button"
-                    title="Remove entry"
+                    title="Удалить запись"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -399,7 +399,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Add entry
+          Добавить запись
         </button>
       </div>
     `;
@@ -419,14 +419,14 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              No entries yet.
+              Пока нет записей.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row">
                   <ha-textfield
                     class="tc-map-key"
-                    label="State"
+                    label="Состояние"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
@@ -439,7 +439,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ></ha-icon-picker>
                   <button
                     class="tc-icon-button"
-                    title="Remove entry"
+                    title="Удалить запись"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -453,7 +453,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Add entry
+          Добавить запись
         </button>
       </div>
     `;
@@ -466,14 +466,14 @@ class TimelineCardEntityEditor extends LitElement {
       <div class="tc-map-editor">
         ${entries.length === 0
           ? html`<div class="tc-muted" style="margin-bottom:6px;">
-              No entries yet.
+              Пока нет записей.
             </div>`
           : entries.map(
               ([state, value]) => html`
                 <div class="tc-map-row tc-map-row-color">
                   <ha-textfield
                     class="tc-map-key"
-                    label="State"
+                    label="Состояние"
                     .value=${state}
                     @input=${(e) =>
                       this._onMapKeyChange(mapKey, state, e.target.value)}
@@ -481,7 +481,7 @@ class TimelineCardEntityEditor extends LitElement {
                   ${this._renderMapColorPicker(mapKey, state, value)}
                   <button
                     class="tc-icon-button"
-                    title="Remove entry"
+                    title="Удалить запись"
                     @click=${() => this._removeMapEntry(mapKey, state)}
                   >
                     <ha-icon icon="mdi:delete"></ha-icon>
@@ -495,7 +495,7 @@ class TimelineCardEntityEditor extends LitElement {
           style="margin-top:6px;"
           @click=${() => this._addMapEntry(mapKey)}
         >
-          Add entry
+          Добавить запись
         </button>
       </div>
     `;
@@ -564,7 +564,7 @@ class TimelineCardEntityEditor extends LitElement {
           />
           <button
             class="tc-icon-button"
-            title="Clear color"
+            title="Сбросить цвет"
             @click=${() => this._updateField(key, undefined)}
           >
             <ha-icon icon="mdi:close"></ha-icon>

--- a/src/editor/entity-list.js
+++ b/src/editor/entity-list.js
@@ -122,12 +122,6 @@ class TimelineCardEntityList extends LitElement {
   _onEntityPicked(ev) {
     const pickedValue = ev.detail?.value;
     this._newEntityId = this._extractEntityId(pickedValue);
-    console.debug('[Timeline Card] ha-selector add entity', {
-      type: ev?.type,
-      rawValue: pickedValue,
-      extractedEntityId: this._newEntityId,
-      detail: ev?.detail,
-    });
   }
 
   _addEntity() {
@@ -148,13 +142,6 @@ class TimelineCardEntityList extends LitElement {
   _onEntityReplaced(index, ev) {
     const selectorValue = ev.detail?.value;
     const id = this._extractEntityId(selectorValue);
-    console.debug('[Timeline Card] ha-selector replace entity', {
-      index,
-      type: ev?.type,
-      rawValue: selectorValue,
-      extractedEntityId: id,
-      detail: ev?.detail,
-    });
     if (!id) return;
 
     const list = [...this.entities];

--- a/src/editor/entity-list.js
+++ b/src/editor/entity-list.js
@@ -27,12 +27,12 @@ class TimelineCardEntityList extends LitElement {
       <div class="tc-section">
         <div class="tc-entities-list">
           <div class="tc-entities-header">
-            <div class="tc-entities-title">Entities</div>
+            <div class="tc-entities-title">Сущности</div>
           </div>
 
           ${entities.length === 0
             ? html`<div style="font-size: 13px; opacity: 0.7;">
-                No entities configured yet.
+                Сущности еще не настроены.
               </div>`
             : entities.map((e, idx) => this._renderEntityRow(e, idx))}
 
@@ -54,13 +54,14 @@ class TimelineCardEntityList extends LitElement {
               @click=${this._addEntity}
               ?disabled=${!this._newEntityId}
             >
-              Add
+              Добавить
             </button>
           </div>
 
           <div class="tc-muted">
-            Entities are added as plain <code>entity:</code> entries first. You
-            can customise them in the entity editor later.
+            Сущности сначала добавляются как обычные записи
+            <code>entity:</code>. Детальную настройку можно сделать позже в
+            редакторе сущности.
           </div>
         </div>
       </div>
@@ -84,7 +85,7 @@ class TimelineCardEntityList extends LitElement {
         <div class="tc-entity-actions">
           <button
             class="tc-icon-button"
-            title="Edit entity options"
+            title="Редактировать сущность"
             @click=${() => this._editEntity(index)}
           >
             <ha-icon icon="mdi:pencil"></ha-icon>
@@ -92,7 +93,7 @@ class TimelineCardEntityList extends LitElement {
 
           <button
             class="tc-icon-button"
-            title="Remove entity"
+            title="Удалить сущность"
             @click=${() => this._removeEntity(index)}
           >
             <ha-icon icon="mdi:delete"></ha-icon>
@@ -110,6 +111,7 @@ class TimelineCardEntityList extends LitElement {
 
     if (typeof sel === 'string') return sel;
     if (sel.entity_id) return sel.entity_id;
+    if (sel.entity) return sel.entity;
     if (sel.value) return sel.value;
 
     return '';
@@ -119,7 +121,14 @@ class TimelineCardEntityList extends LitElement {
   // ADD NEW ENTITY
   //
   _onEntityPicked(ev) {
-    this._newEntityId = this._extractEntityId(ev.detail?.value);
+    const pickedValue = ev.detail?.value;
+    this._newEntityId = this._extractEntityId(pickedValue);
+    console.debug('[Timeline Card] ha-selector add entity', {
+      type: ev?.type,
+      rawValue: pickedValue,
+      extractedEntityId: this._newEntityId,
+      detail: ev?.detail,
+    });
   }
 
   _addEntity() {
@@ -138,7 +147,15 @@ class TimelineCardEntityList extends LitElement {
   // REPLACE EXISTING ENTITY
   //
   _onEntityReplaced(index, ev) {
-    const id = this._extractEntityId(ev.detail?.value);
+    const selectorValue = ev.detail?.value;
+    const id = this._extractEntityId(selectorValue);
+    console.debug('[Timeline Card] ha-selector replace entity', {
+      index,
+      type: ev?.type,
+      rawValue: selectorValue,
+      extractedEntityId: id,
+      detail: ev?.detail,
+    });
     if (!id) return;
 
     const list = [...this.entities];

--- a/src/editor/entity-list.js
+++ b/src/editor/entity-list.js
@@ -27,12 +27,12 @@ class TimelineCardEntityList extends LitElement {
       <div class="tc-section">
         <div class="tc-entities-list">
           <div class="tc-entities-header">
-            <div class="tc-entities-title">Сущности</div>
+            <div class="tc-entities-title">Entities</div>
           </div>
 
           ${entities.length === 0
             ? html`<div style="font-size: 13px; opacity: 0.7;">
-                Сущности еще не настроены.
+                No entities configured yet.
               </div>`
             : entities.map((e, idx) => this._renderEntityRow(e, idx))}
 
@@ -54,14 +54,13 @@ class TimelineCardEntityList extends LitElement {
               @click=${this._addEntity}
               ?disabled=${!this._newEntityId}
             >
-              Добавить
+              Add
             </button>
           </div>
 
           <div class="tc-muted">
-            Сущности сначала добавляются как обычные записи
-            <code>entity:</code>. Детальную настройку можно сделать позже в
-            редакторе сущности.
+            Entities are added as plain <code>entity:</code> entries first. You
+            can customise them in the entity editor later.
           </div>
         </div>
       </div>
@@ -85,7 +84,7 @@ class TimelineCardEntityList extends LitElement {
         <div class="tc-entity-actions">
           <button
             class="tc-icon-button"
-            title="Редактировать сущность"
+            title="Edit entity options"
             @click=${() => this._editEntity(index)}
           >
             <ha-icon icon="mdi:pencil"></ha-icon>
@@ -93,7 +92,7 @@ class TimelineCardEntityList extends LitElement {
 
           <button
             class="tc-icon-button"
-            title="Удалить сущность"
+            title="Remove entity"
             @click=${() => this._removeEntity(index)}
           >
             <ha-icon icon="mdi:delete"></ha-icon>

--- a/src/editor/general-settings.js
+++ b/src/editor/general-settings.js
@@ -11,6 +11,7 @@ class TimelineCardGeneralSettings extends LitElement {
   static get properties() {
     return {
       config: { type: Object },
+      hass: { type: Object },
     };
   }
 
@@ -28,16 +29,18 @@ class TimelineCardGeneralSettings extends LitElement {
       <div class="tc-editor-root">
         <!-- SECTION: General -->
         <div class="tc-section">
-          <h3 class="tc-section-title">General</h3>
-          <div class="tc-section-subtitle">Title, language and refresh.</div>
+          <h3 class="tc-section-title">Общие</h3>
+          <div class="tc-section-subtitle">Заголовок, язык и обновление.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- TITLE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Title</div>
-                  <div class="tc-setting-description">Optional card title.</div>
+                  <div class="tc-setting-title">Заголовок</div>
+                  <div class="tc-setting-description">
+                    Необязательный заголовок карточки.
+                  </div>
                 </div>
                 <ha-textfield
                   style="min-width: 200px; width: 280px; max-width: 280px;"
@@ -49,34 +52,43 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- LANGUAGE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Language</div>
+                  <div class="tc-setting-title">Язык</div>
                   <div class="tc-setting-description">
-                    Optional override. Empty = auto from HA/browser.
+                    Необязательное переопределение. Пусто = автоматически из
+                    HA/браузера.
                   </div>
                 </div>
-                <ha-select
+                <ha-selector
                   style="min-width: 200px; width: 240px;"
+                  .hass=${this.hass}
                   .value=${cfg.language || ''}
-                  @selected=${(e) => this._onSelectChange('language', e)}
-                  @closed=${(e) => e.stopPropagation()}
-                >
-                  <mwc-list-item value="">Auto</mwc-list-item>
-                  <mwc-list-item value="de">Deutsch</mwc-list-item>
-                  <mwc-list-item value="en-GB">English (UK)</mwc-list-item>
-                  <mwc-list-item value="en-US">English (US)</mwc-list-item>
-                  <mwc-list-item value="fr">Francais</mwc-list-item>
-                  <mwc-list-item value="it">Italiano</mwc-list-item>
-                  <mwc-list-item value="pt-br">Portugues (BR)</mwc-list-item>
-                  <mwc-list-item value="sv">Svensk</mwc-list-item>
-                </ha-select>
+                  .selector=${{
+                    select: {
+                      mode: 'dropdown',
+                      options: [
+                        { value: '', label: 'Авто' },
+                        { value: 'de', label: 'Deutsch' },
+                        { value: 'en-GB', label: 'English (UK)' },
+                        { value: 'en-US', label: 'English (US)' },
+                        { value: 'fr', label: 'Francais' },
+                        { value: 'it', label: 'Italiano' },
+                        { value: 'pt-br', label: 'Portugues (BR)' },
+                        { value: 'ru', label: 'Русский' },
+                        { value: 'sv', label: 'Svensk' },
+                      ],
+                    },
+                  }}
+                  @value-changed=${(e) =>
+                    this._onSelectorChange('language', e, true)}
+                ></ha-selector>
               </div>
 
               <!-- REFRESH INTERVAL -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Refresh interval (s)</div>
+                  <div class="tc-setting-title">Интервал обновления (с)</div>
                   <div class="tc-setting-description">
-                    Optional auto-refresh interval in seconds.
+                    Необязательный интервал автообновления в секундах.
                   </div>
                 </div>
                 <ha-textfield
@@ -94,17 +106,17 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Range & data -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Range & data</h3>
-          <div class="tc-section-subtitle">How much history is loaded.</div>
+          <h3 class="tc-section-title">Период и данные</h3>
+          <div class="tc-section-subtitle">Сколько истории загружать.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- HOURS -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Hours</div>
+                  <div class="tc-setting-title">Часы</div>
                   <div class="tc-setting-description">
-                    Number of hours of history to fetch.
+                    Количество часов истории для загрузки.
                   </div>
                 </div>
                 <ha-textfield
@@ -119,9 +131,9 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- LIMIT -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Limit</div>
+                  <div class="tc-setting-title">Лимит</div>
                   <div class="tc-setting-description">
-                    Max number of events to display.
+                    Максимальное количество отображаемых событий.
                   </div>
                 </div>
                 <ha-textfield
@@ -138,9 +150,9 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Event display -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Event display</h3>
+          <h3 class="tc-section-title">Отображение событий</h3>
           <div class="tc-section-subtitle">
-            Collapsing vs. scroll and how many events to show.
+            Сворачивание, прокрутка и количество видимых событий.
           </div>
 
           <div class="tc-card-block">
@@ -150,9 +162,9 @@ class TimelineCardGeneralSettings extends LitElement {
                 ? html`
                     <div class="tc-setting-row">
                       <div class="tc-setting-label">
-                        <div class="tc-setting-title">Visible events</div>
+                        <div class="tc-setting-title">Видимые события</div>
                         <div class="tc-setting-description">
-                          Show this many before "Show more".
+                          Показывать столько элементов до кнопки "Показать еще".
                         </div>
                       </div>
                       <ha-textfield
@@ -173,24 +185,33 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- OVERFLOW MODE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Overflow mode</div>
+                  <div class="tc-setting-title">Режим переполнения</div>
                   <div class="tc-setting-description">
-                    Collapse extra events or render inside a scroll area.
+                    Свернуть лишние события или показывать их в области прокрутки.
                   </div>
                 </div>
-                <ha-select
+                <ha-selector
                   style="min-width: 180px; width: 200px;"
+                  .hass=${this.hass}
                   .value=${cfg.overflow || 'collapse'}
-                  @selected=${(e) => this._onSelectChange('overflow', e)}
-                  @closed=${(e) => e.stopPropagation()}
-                >
-                  <mwc-list-item value="collapse"
-                    >Collapse (show more/less)</mwc-list-item
-                  >
-                  <mwc-list-item value="scroll"
-                    >Scroll (respect max height)</mwc-list-item
-                  >
-                </ha-select>
+                  .selector=${{
+                    select: {
+                      mode: 'dropdown',
+                      options: [
+                        {
+                          value: 'collapse',
+                          label: 'Сворачивать (показать больше/меньше)',
+                        },
+                        {
+                          value: 'scroll',
+                          label: 'Прокрутка (с учетом max height)',
+                        },
+                      ],
+                    },
+                  }}
+                  @value-changed=${(e) =>
+                    this._onSelectorChange('overflow', e, false, 'collapse')}
+                ></ha-selector>
               </div>
 
               <!-- MAX HEIGHT (scroll only) -->
@@ -198,9 +219,9 @@ class TimelineCardGeneralSettings extends LitElement {
                 ? html`
                     <div class="tc-setting-row">
                       <div class="tc-setting-label">
-                        <div class="tc-setting-title">Max height</div>
+                        <div class="tc-setting-title">Максимальная высота</div>
                         <div class="tc-setting-description">
-                          Limit card height (e.g. 220px or 14rem).
+                          Ограничение высоты карточки (например, 220px или 14rem).
                         </div>
                       </div>
                       <ha-textfield
@@ -218,37 +239,38 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Layout -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Layout</h3>
+          <h3 class="tc-section-title">Расположение</h3>
           <div class="tc-section-subtitle">
-            Where the timeline line and cards appear.
+            Положение линии таймлайна и карточек событий.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Card layout</div>
+                  <div class="tc-setting-title">Макет карточки</div>
                   <div class="tc-setting-description">
-                    Switch between centered (alternating) and single-sided
-                    layouts.
+                    Переключение между центральным (чередующимся) и
+                    односторонними макетами.
                   </div>
                 </div>
-                <ha-select
+                <ha-selector
                   style="min-width: 200px; width: 240px;"
+                  .hass=${this.hass}
                   .value=${cfg.card_layout || 'center'}
-                  @selected=${(e) => this._onSelectChange('card_layout', e)}
-                  @closed=${(e) => e.stopPropagation()}
-                >
-                  <mwc-list-item value="center"
-                    >Center (alternating)</mwc-list-item
-                  >
-                  <mwc-list-item value="left"
-                    >Left line, cards right</mwc-list-item
-                  >
-                  <mwc-list-item value="right"
-                    >Right line, cards left</mwc-list-item
-                  >
-                </ha-select>
+                  .selector=${{
+                    select: {
+                      mode: 'dropdown',
+                      options: [
+                        { value: 'center', label: 'Центр (чередование)' },
+                        { value: 'left', label: 'Линия слева, карточки справа' },
+                        { value: 'right', label: 'Линия справа, карточки слева' },
+                      ],
+                    },
+                  }}
+                  @value-changed=${(e) =>
+                    this._onSelectorChange('card_layout', e, false, 'center')}
+                ></ha-selector>
               </div>
 
               ${this._compactRow(cfg)}
@@ -258,38 +280,38 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Content -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Content</h3>
-          <div class="tc-section-subtitle">What is shown for each event.</div>
+          <h3 class="tc-section-title">Содержимое</h3>
+          <div class="tc-section-subtitle">Что отображать в каждом событии.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Show names',
-                'Show the entity name in the timeline.',
+                'Показывать имена',
+                'Показывать имя сущности в таймлайне.',
                 'show_names',
                 cfg.show_names ?? true
               )}
               ${this._booleanRow(
-                'Show states',
-                'Display the entity state next to the name.',
+                'Показывать состояния',
+                'Показывать состояние рядом с именем.',
                 'show_states',
                 cfg.show_states ?? true
               )}
               ${this._booleanRow(
-                'Show icons',
-                'Add the entity icon to each event.',
+                'Показывать иконки',
+                'Показывать иконку сущности у каждого события.',
                 'show_icons',
                 cfg.show_icons ?? true
               )}
               ${this._booleanRow(
-                'Use relative time',
-                'Show relative timestamps like 5 minutes ago.',
+                'Использовать относительное время',
+                'Показывать время в формате "5 минут назад".',
                 'relative_time',
                 cfg.relative_time ?? false
               )}
               ${this._booleanRow(
-                'Show date',
-                'Include the date for absolute timestamps; turn off to display time only.',
+                'Показывать дату',
+                'Добавлять дату для абсолютного времени; отключите, чтобы показывать только время.',
                 'show_date',
                 cfg.show_date ?? true
               )}
@@ -299,22 +321,22 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Text formatting -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Text formatting</h3>
+          <h3 class="tc-section-title">Формат текста</h3>
           <div class="tc-section-subtitle">
-            Control wrapping of names and states.
+            Перенос строк для имен и состояний.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Allow multiline',
-                'Allow names and states to wrap across multiple lines.',
+                'Разрешить многострочный текст',
+                'Разрешить перенос имен и состояний на несколько строк.',
                 'allow_multiline',
                 cfg.allow_multiline ?? false
               )}
               ${this._booleanRow(
-                'Force multiline',
-                'Always place the state on a new line under the name.',
+                'Принудительно многострочно',
+                'Всегда переносить состояние на новую строку под именем.',
                 'force_multiline',
                 cfg.force_multiline ?? false
               )}
@@ -324,16 +346,16 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Duplicates -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Duplicates & filters</h3>
+          <h3 class="tc-section-title">Дубликаты и фильтры</h3>
           <div class="tc-section-subtitle">
-            Collapse repeating states globally.
+            Глобально скрывать повторяющиеся подряд состояния.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Collapse duplicates',
-                'Hide consecutive events with the same state.',
+                'Скрывать дубликаты',
+                'Скрывать последовательные события с одинаковым состоянием.',
                 'collapse_duplicates',
                 cfg.collapse_duplicates ?? false
               )}
@@ -343,9 +365,9 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Colors -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Colors</h3>
+          <h3 class="tc-section-title">Цвета</h3>
           <div class="tc-section-subtitle">
-            Optional static colors for name and state (applied globally).
+            Необязательные статические цвета для карточки и текста.
           </div>
           <div class="tc-card-block">
             <div class="tc-form-group">
@@ -353,14 +375,14 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'card_background',
                   cfg.card_background,
-                  'Card background color'
+                  'Цвет фона карточки'
                 )}
               </div>
               <div class="tc-color-row">
                 ${this._renderColorPicker(
                   'timeline_color_start',
                   cfg.timeline_color_start,
-                  'Timeline gradient start',
+                  'Начало градиента линии',
                   '#2da8ff'
                 )}
               </div>
@@ -368,7 +390,7 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'timeline_color_end',
                   cfg.timeline_color_end,
-                  'Timeline gradient end',
+                  'Конец градиента линии',
                   '#b24aff'
                 )}
               </div>
@@ -376,7 +398,7 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'dot_color',
                   cfg.dot_color,
-                  'Dot color',
+                  'Цвет точки',
                   '#31a8ff'
                 )}
               </div>
@@ -384,14 +406,14 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'name_color',
                   cfg.name_color,
-                  'Name color'
+                  'Цвет имени'
                 )}
               </div>
               <div class="tc-color-row">
                 ${this._renderColorPicker(
                   'state_color',
                   cfg.state_color,
-                  'State color'
+                  'Цвет состояния'
                 )}
               </div>
             </div>
@@ -459,7 +481,7 @@ class TimelineCardGeneralSettings extends LitElement {
           />
           <button
             class="tc-icon-button"
-            title="Clear color"
+            title="Сбросить цвет"
             @click=${() => this._onColorChange(key, undefined)}
           >
             <ha-icon icon="mdi:close"></ha-icon>
@@ -511,9 +533,13 @@ class TimelineCardGeneralSettings extends LitElement {
     this._emitPatch({ [key]: v || undefined });
   }
 
-  _onSelectChange(key, ev) {
-    const val = ev.target?.value ?? '';
-    const patch = { [key]: val || undefined };
+  _onSelectChange(key, rawValue, keepEmpty = false, fallbackValue) {
+    const val = `${rawValue ?? ''}`.trim();
+    const patch = { [key]: val || (keepEmpty ? '' : undefined) };
+
+    if (!val && fallbackValue) {
+      patch[key] = fallbackValue;
+    }
 
     // If layout switches away from center, turn off compact to avoid invalid combo
     if (key === 'card_layout' && val && val !== 'center') {
@@ -523,14 +549,34 @@ class TimelineCardGeneralSettings extends LitElement {
     this._emitPatch(patch);
   }
 
+  _onSelectorChange(key, ev, keepEmpty = false, fallbackValue) {
+    const eventValue =
+      ev?.detail?.value ??
+      ev?.target?.value ??
+      ev?.target?.__value ??
+      ev?.target?.configValue ??
+      '';
+    // Debug info for HA selector regressions across frontend versions.
+    console.debug('[Timeline Card] ha-selector event', {
+      key,
+      type: ev?.type,
+      eventValue,
+      targetValue: ev?.target?.value,
+      detailValue: ev?.detail?.value,
+      target: ev?.target?.tagName,
+      detail: ev?.detail,
+    });
+    this._onSelectChange(key, eventValue, keepEmpty, fallbackValue);
+  }
+
   _compactRow(cfg) {
     const layout = cfg.card_layout || 'center';
     const disabled = layout !== 'center';
     const desc = disabled
-      ? 'Center layout required.'
-      : 'Overlap rows to reduce the vertical height of the timeline.';
+      ? 'Доступно только для макета "Центр".'
+      : 'Перекрывать ряды, чтобы уменьшить вертикальную высоту таймлайна.';
     return this._booleanRow(
-      'Compact layout',
+      'Компактный макет',
       desc,
       'compact_layout',
       cfg.compact_layout ?? false,

--- a/src/editor/general-settings.js
+++ b/src/editor/general-settings.js
@@ -29,17 +29,17 @@ class TimelineCardGeneralSettings extends LitElement {
       <div class="tc-editor-root">
         <!-- SECTION: General -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Общие</h3>
-          <div class="tc-section-subtitle">Заголовок, язык и обновление.</div>
+          <h3 class="tc-section-title">General</h3>
+          <div class="tc-section-subtitle">Title, language and refresh.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- TITLE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Заголовок</div>
+                  <div class="tc-setting-title">Title</div>
                   <div class="tc-setting-description">
-                    Необязательный заголовок карточки.
+                    Optional card title.
                   </div>
                 </div>
                 <ha-textfield
@@ -52,10 +52,9 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- LANGUAGE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Язык</div>
+                  <div class="tc-setting-title">Language</div>
                   <div class="tc-setting-description">
-                    Необязательное переопределение. Пусто = автоматически из
-                    HA/браузера.
+                    Optional override. Empty = auto from HA/browser.
                   </div>
                 </div>
                 <ha-selector
@@ -66,14 +65,14 @@ class TimelineCardGeneralSettings extends LitElement {
                     select: {
                       mode: 'dropdown',
                       options: [
-                        { value: '', label: 'Авто' },
+                        { value: '', label: 'Auto' },
                         { value: 'de', label: 'Deutsch' },
                         { value: 'en-GB', label: 'English (UK)' },
                         { value: 'en-US', label: 'English (US)' },
                         { value: 'fr', label: 'Francais' },
                         { value: 'it', label: 'Italiano' },
                         { value: 'pt-br', label: 'Portugues (BR)' },
-                        { value: 'ru', label: 'Русский' },
+                        { value: 'ru', label: 'Russian' },
                         { value: 'sv', label: 'Svensk' },
                       ],
                     },
@@ -86,9 +85,9 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- REFRESH INTERVAL -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Интервал обновления (с)</div>
+                  <div class="tc-setting-title">Refresh interval (s)</div>
                   <div class="tc-setting-description">
-                    Необязательный интервал автообновления в секундах.
+                    Optional auto-refresh interval in seconds.
                   </div>
                 </div>
                 <ha-textfield
@@ -106,17 +105,17 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Range & data -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Период и данные</h3>
-          <div class="tc-section-subtitle">Сколько истории загружать.</div>
+          <h3 class="tc-section-title">Range & data</h3>
+          <div class="tc-section-subtitle">How much history is loaded.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <!-- HOURS -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Часы</div>
+                  <div class="tc-setting-title">Hours</div>
                   <div class="tc-setting-description">
-                    Количество часов истории для загрузки.
+                    Number of hours of history to fetch.
                   </div>
                 </div>
                 <ha-textfield
@@ -131,9 +130,9 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- LIMIT -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Лимит</div>
+                  <div class="tc-setting-title">Limit</div>
                   <div class="tc-setting-description">
-                    Максимальное количество отображаемых событий.
+                    Max number of events to display.
                   </div>
                 </div>
                 <ha-textfield
@@ -150,9 +149,9 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Event display -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Отображение событий</h3>
+          <h3 class="tc-section-title">Event display</h3>
           <div class="tc-section-subtitle">
-            Сворачивание, прокрутка и количество видимых событий.
+            Collapsing vs. scroll and how many events to show.
           </div>
 
           <div class="tc-card-block">
@@ -162,9 +161,9 @@ class TimelineCardGeneralSettings extends LitElement {
                 ? html`
                     <div class="tc-setting-row">
                       <div class="tc-setting-label">
-                        <div class="tc-setting-title">Видимые события</div>
+                        <div class="tc-setting-title">Visible events</div>
                         <div class="tc-setting-description">
-                          Показывать столько элементов до кнопки "Показать еще".
+                          Show this many before "Show more".
                         </div>
                       </div>
                       <ha-textfield
@@ -185,9 +184,9 @@ class TimelineCardGeneralSettings extends LitElement {
               <!-- OVERFLOW MODE -->
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Режим переполнения</div>
+                  <div class="tc-setting-title">Overflow mode</div>
                   <div class="tc-setting-description">
-                    Свернуть лишние события или показывать их в области прокрутки.
+                    Collapse extra events or render inside a scroll area.
                   </div>
                 </div>
                 <ha-selector
@@ -200,11 +199,11 @@ class TimelineCardGeneralSettings extends LitElement {
                       options: [
                         {
                           value: 'collapse',
-                          label: 'Сворачивать (показать больше/меньше)',
+                          label: 'Collapse (show more/less)',
                         },
                         {
                           value: 'scroll',
-                          label: 'Прокрутка (с учетом max height)',
+                          label: 'Scroll (respect max height)',
                         },
                       ],
                     },
@@ -219,9 +218,9 @@ class TimelineCardGeneralSettings extends LitElement {
                 ? html`
                     <div class="tc-setting-row">
                       <div class="tc-setting-label">
-                        <div class="tc-setting-title">Максимальная высота</div>
+                        <div class="tc-setting-title">Max height</div>
                         <div class="tc-setting-description">
-                          Ограничение высоты карточки (например, 220px или 14rem).
+                          Limit card height (e.g. 220px or 14rem).
                         </div>
                       </div>
                       <ha-textfield
@@ -239,19 +238,19 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Layout -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Расположение</h3>
+          <h3 class="tc-section-title">Layout</h3>
           <div class="tc-section-subtitle">
-            Положение линии таймлайна и карточек событий.
+            Where the timeline line and cards appear.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               <div class="tc-setting-row">
                 <div class="tc-setting-label">
-                  <div class="tc-setting-title">Макет карточки</div>
+                  <div class="tc-setting-title">Card layout</div>
                   <div class="tc-setting-description">
-                    Переключение между центральным (чередующимся) и
-                    односторонними макетами.
+                    Switch between centered (alternating) and single-sided
+                    layouts.
                   </div>
                 </div>
                 <ha-selector
@@ -262,9 +261,9 @@ class TimelineCardGeneralSettings extends LitElement {
                     select: {
                       mode: 'dropdown',
                       options: [
-                        { value: 'center', label: 'Центр (чередование)' },
-                        { value: 'left', label: 'Линия слева, карточки справа' },
-                        { value: 'right', label: 'Линия справа, карточки слева' },
+                        { value: 'center', label: 'Center (alternating)' },
+                        { value: 'left', label: 'Left line, cards right' },
+                        { value: 'right', label: 'Right line, cards left' },
                       ],
                     },
                   }}
@@ -280,38 +279,38 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Content -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Содержимое</h3>
-          <div class="tc-section-subtitle">Что отображать в каждом событии.</div>
+          <h3 class="tc-section-title">Content</h3>
+          <div class="tc-section-subtitle">What is shown for each event.</div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Показывать имена',
-                'Показывать имя сущности в таймлайне.',
+                'Show names',
+                'Show the entity name in the timeline.',
                 'show_names',
                 cfg.show_names ?? true
               )}
               ${this._booleanRow(
-                'Показывать состояния',
-                'Показывать состояние рядом с именем.',
+                'Show states',
+                'Display the entity state next to the name.',
                 'show_states',
                 cfg.show_states ?? true
               )}
               ${this._booleanRow(
-                'Показывать иконки',
-                'Показывать иконку сущности у каждого события.',
+                'Show icons',
+                'Add the entity icon to each event.',
                 'show_icons',
                 cfg.show_icons ?? true
               )}
               ${this._booleanRow(
-                'Использовать относительное время',
-                'Показывать время в формате "5 минут назад".',
+                'Use relative time',
+                'Show relative timestamps like 5 minutes ago.',
                 'relative_time',
                 cfg.relative_time ?? false
               )}
               ${this._booleanRow(
-                'Показывать дату',
-                'Добавлять дату для абсолютного времени; отключите, чтобы показывать только время.',
+                'Show date',
+                'Include the date for absolute timestamps; turn off to display time only.',
                 'show_date',
                 cfg.show_date ?? true
               )}
@@ -321,22 +320,22 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Text formatting -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Формат текста</h3>
+          <h3 class="tc-section-title">Text formatting</h3>
           <div class="tc-section-subtitle">
-            Перенос строк для имен и состояний.
+            Control wrapping of names and states.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Разрешить многострочный текст',
-                'Разрешить перенос имен и состояний на несколько строк.',
+                'Allow multiline',
+                'Allow names and states to wrap across multiple lines.',
                 'allow_multiline',
                 cfg.allow_multiline ?? false
               )}
               ${this._booleanRow(
-                'Принудительно многострочно',
-                'Всегда переносить состояние на новую строку под именем.',
+                'Force multiline',
+                'Always place the state on a new line under the name.',
                 'force_multiline',
                 cfg.force_multiline ?? false
               )}
@@ -346,16 +345,16 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Duplicates -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Дубликаты и фильтры</h3>
+          <h3 class="tc-section-title">Duplicates & filters</h3>
           <div class="tc-section-subtitle">
-            Глобально скрывать повторяющиеся подряд состояния.
+            Collapse repeating states globally.
           </div>
 
           <div class="tc-card-block">
             <div class="tc-form-group">
               ${this._booleanRow(
-                'Скрывать дубликаты',
-                'Скрывать последовательные события с одинаковым состоянием.',
+                'Collapse duplicates',
+                'Hide consecutive events with the same state.',
                 'collapse_duplicates',
                 cfg.collapse_duplicates ?? false
               )}
@@ -365,9 +364,9 @@ class TimelineCardGeneralSettings extends LitElement {
 
         <!-- SECTION: Colors -->
         <div class="tc-section">
-          <h3 class="tc-section-title">Цвета</h3>
+          <h3 class="tc-section-title">Colors</h3>
           <div class="tc-section-subtitle">
-            Необязательные статические цвета для карточки и текста.
+            Optional static colors for name and state (applied globally).
           </div>
           <div class="tc-card-block">
             <div class="tc-form-group">
@@ -375,14 +374,14 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'card_background',
                   cfg.card_background,
-                  'Цвет фона карточки'
+                  'Card background color'
                 )}
               </div>
               <div class="tc-color-row">
                 ${this._renderColorPicker(
                   'timeline_color_start',
                   cfg.timeline_color_start,
-                  'Начало градиента линии',
+                  'Timeline gradient start',
                   '#2da8ff'
                 )}
               </div>
@@ -390,7 +389,7 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'timeline_color_end',
                   cfg.timeline_color_end,
-                  'Конец градиента линии',
+                  'Timeline gradient end',
                   '#b24aff'
                 )}
               </div>
@@ -398,7 +397,7 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'dot_color',
                   cfg.dot_color,
-                  'Цвет точки',
+                  'Dot color',
                   '#31a8ff'
                 )}
               </div>
@@ -406,14 +405,14 @@ class TimelineCardGeneralSettings extends LitElement {
                 ${this._renderColorPicker(
                   'name_color',
                   cfg.name_color,
-                  'Цвет имени'
+                  'Name color'
                 )}
               </div>
               <div class="tc-color-row">
                 ${this._renderColorPicker(
                   'state_color',
                   cfg.state_color,
-                  'Цвет состояния'
+                  'State color'
                 )}
               </div>
             </div>
@@ -481,7 +480,7 @@ class TimelineCardGeneralSettings extends LitElement {
           />
           <button
             class="tc-icon-button"
-            title="Сбросить цвет"
+            title="Clear color"
             @click=${() => this._onColorChange(key, undefined)}
           >
             <ha-icon icon="mdi:close"></ha-icon>
@@ -573,10 +572,10 @@ class TimelineCardGeneralSettings extends LitElement {
     const layout = cfg.card_layout || 'center';
     const disabled = layout !== 'center';
     const desc = disabled
-      ? 'Доступно только для макета "Центр".'
-      : 'Перекрывать ряды, чтобы уменьшить вертикальную высоту таймлайна.';
+      ? 'Center layout required.'
+      : 'Overlap rows to reduce the vertical height of the timeline.';
     return this._booleanRow(
-      'Компактный макет',
+      'Compact layout',
       desc,
       'compact_layout',
       cfg.compact_layout ?? false,

--- a/src/editor/general-settings.js
+++ b/src/editor/general-settings.js
@@ -555,16 +555,6 @@ class TimelineCardGeneralSettings extends LitElement {
       ev?.target?.__value ??
       ev?.target?.configValue ??
       '';
-    // Debug info for HA selector regressions across frontend versions.
-    console.debug('[Timeline Card] ha-selector event', {
-      key,
-      type: ev?.type,
-      eventValue,
-      targetValue: ev?.target?.value,
-      detailValue: ev?.detail?.value,
-      target: ev?.target?.tagName,
-      detail: ev?.detail,
-    });
     this._onSelectChange(key, eventValue, keepEmpty, fallbackValue);
   }
 

--- a/src/editor/timeline-card-editor.js
+++ b/src/editor/timeline-card-editor.js
@@ -78,15 +78,15 @@ class TimelineCardEditor extends LitElement {
       </style>
       <div class="tc-editor-root">
         <div class="tc-header">
-          <div class="tc-header-title">Timeline Card</div>
+          <div class="tc-header-title">Карточка таймлайна</div>
         </div>
 
         <div class="tc-section">
           <button class="tc-row-button" @click=${this._openCardSettings}>
             <div class="tc-row-button-label">
-              <span class="tc-row-button-title">General settings</span>
+              <span class="tc-row-button-title">Общие настройки</span>
               <span class="tc-row-button-sub">
-                Configure global behaviour and layout of the timeline.
+                Настройка общего поведения и внешнего вида таймлайна.
               </span>
             </div>
             <span>›</span>
@@ -113,15 +113,16 @@ class TimelineCardEditor extends LitElement {
         <div class="tc-header">
           <button
             class="tc-icon-button"
-            title="Back"
+            title="Назад"
             @click=${() => this._goTo('main')}
           >
             <ha-icon icon="mdi:arrow-left"></ha-icon>
           </button>
-          <div class="tc-header-title">Card settings</div>
+          <div class="tc-header-title">Настройки карточки</div>
         </div>
 
         <timeline-card-general-settings
+          .hass=${this.hass}
           .config=${this._config}
           @settings-changed=${this._onSettingsChanged}
         ></timeline-card-general-settings>
@@ -143,12 +144,12 @@ class TimelineCardEditor extends LitElement {
         <div class="tc-header">
           <button
             class="tc-icon-button"
-            title="Back"
+            title="Назад"
             @click=${() => this._goTo('main')}
           >
             <ha-icon icon="mdi:arrow-left"></ha-icon>
           </button>
-          <div class="tc-header-title">Entity settings</div>
+          <div class="tc-header-title">Настройки сущности</div>
         </div>
 
         <timeline-card-entity-editor

--- a/src/editor/timeline-card-editor.js
+++ b/src/editor/timeline-card-editor.js
@@ -78,15 +78,15 @@ class TimelineCardEditor extends LitElement {
       </style>
       <div class="tc-editor-root">
         <div class="tc-header">
-          <div class="tc-header-title">Карточка таймлайна</div>
+          <div class="tc-header-title">Timeline Card</div>
         </div>
 
         <div class="tc-section">
           <button class="tc-row-button" @click=${this._openCardSettings}>
             <div class="tc-row-button-label">
-              <span class="tc-row-button-title">Общие настройки</span>
+              <span class="tc-row-button-title">General settings</span>
               <span class="tc-row-button-sub">
-                Настройка общего поведения и внешнего вида таймлайна.
+                Configure global behaviour and layout of the timeline.
               </span>
             </div>
             <span>›</span>
@@ -113,12 +113,12 @@ class TimelineCardEditor extends LitElement {
         <div class="tc-header">
           <button
             class="tc-icon-button"
-            title="Назад"
+            title="Back"
             @click=${() => this._goTo('main')}
           >
             <ha-icon icon="mdi:arrow-left"></ha-icon>
           </button>
-          <div class="tc-header-title">Настройки карточки</div>
+          <div class="tc-header-title">Card settings</div>
         </div>
 
         <timeline-card-general-settings
@@ -144,12 +144,12 @@ class TimelineCardEditor extends LitElement {
         <div class="tc-header">
           <button
             class="tc-icon-button"
-            title="Назад"
+            title="Back"
             @click=${() => this._goTo('main')}
           >
             <ha-icon icon="mdi:arrow-left"></ha-icon>
           </button>
-          <div class="tc-header-title">Настройки сущности</div>
+          <div class="tc-header-title">Entity settings</div>
         </div>
 
         <timeline-card-entity-editor

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,0 +1,65 @@
+{
+  "time": {
+    "seconds": "несколько секунд назад",
+    "minutes": "{n} минут назад",
+    "hours": "{n} часов назад",
+    "days": "{n} дней назад"
+  },
+  "status": {
+    "locked": "заперто",
+    "unlocked": "отперто",
+    "open": "открыто",
+    "closed": "закрыто",
+    "on": "включено",
+    "off": "выключено",
+    "home": "дома",
+    "not_home": "не дома",
+    "idle": "ожидание",
+    "running": "работает",
+    "paused": "пауза",
+    "stopped": "остановлено",
+    "pending": "ожидание",
+    "unknown": "неизвестно",
+    "unavailable": "недоступно",
+    "detected": "обнаружено",
+    "clear": "чисто",
+    "online": "в сети",
+    "offline": "не в сети",
+    "playing": "воспроизведение",
+    "buffering": "буферизация",
+    "standby": "ожидание",
+    "cleaning": "уборка",
+    "returning": "возвращается",
+    "docked": "на базе",
+    "charging": "заряжается",
+    "error": "ошибка",
+    "spot_cleaning": "локальная уборка",
+    "edge_cleaning": "уборка по краям",
+    "mopping": "влажная уборка",
+    "locating": "поиск",
+    "moving": "движение",
+    "stuck": "застрял",
+    "disarmed": "снято с охраны",
+    "armed_home": "охрана (дома)",
+    "armed_away": "охрана (вне дома)",
+    "armed_night": "охрана (ночь)",
+    "armed_custom_bypass": "охрана (пользовательский режим)",
+    "arming": "постановка на охрану",
+    "disarming": "снятие с охраны",
+    "triggered": "сработало"
+  },
+  "ui": {
+    "show_more": "Показать еще {n}",
+    "show_less": "Показать меньше",
+    "no_events": "Нет событий за выбранный период."
+  },
+  "date_format": {
+    "datetime": {
+      "day": "2-digit",
+      "month": "2-digit",
+      "year": "numeric",
+      "hour": "2-digit",
+      "minute": "2-digit"
+    }
+  }
+}

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -4,6 +4,7 @@ import enUS from './locales/en-US.json';
 import fr from './locales/fr.json';
 import it from './locales/it.json';
 import ptBR from './locales/pt-BR.json';
+import ru from './locales/ru.json';
 import sv from './locales/sv.json';
 import styles from './timeline-card.css';
 
@@ -28,6 +29,7 @@ const translations = {
   fr,
   it,
   'pt-br': ptBR,
+  ru,
   sv,
 };
 
@@ -151,7 +153,6 @@ class TimelineCard extends HTMLElement {
   }
 
   ensureCardExists() {
-    console.log('test');
     const root = this.shadowRoot;
     if (!root.querySelector('style')) {
       const styleEl = document.createElement('style');

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -278,7 +278,6 @@ class TimelineCard extends HTMLElement {
     if (this.refreshTimer) clearInterval(this.refreshTimer);
 
     this.refreshTimer = setInterval(() => {
-      console.debug('TimelineCard Auto-Refresh');
       this.refreshInBackground();
     }, this.refreshInterval * 1000);
   }


### PR DESCRIPTION
- Added full Russian translation support (ru) for timeline states and UI strings.
- Localized editor UI labels and descriptions to Russian.
- Reworked problematic configurator selectors to improve compatibility with recent Home Assistant frontend changes.
- Added selector debug logging for diagnostics and removed temporary test logging.
- Updated docs to include newly supported locales.