### PR TITLE
Add Czech localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ entities:
 | `show_names`           | boolean | no       | true     | Show entity names                                                                                              |
 | `show_states`          | boolean | no       | true     | Show entity states                                                                                             |
 | `show_icons`           | boolean | no       | true     | Show entity icons                                                                                              |
-| `language`             | string  | no       | auto     | Language code (default `en-US`; supports `en-US`, `en-GB`, `de`, `fr`, `it`, `pt-BR`, `ru`, `sv`, etc.)        |
+| `language`             | string  | no       | auto     | Language code (default `en-US`; supports `cs`, `en-US`, `en-GB`, `de`, `fr`, `it`, `pt-BR`, `ru`, `sv`, etc.)  |
 | `refresh_interval`     | number  | no       | -        | Auto-refresh interval in seconds (background refresh)                                                          |
 | `allow_multiline`      | boolean | no       | false    | Enables automatic multiline wrapping for long names/states                                                     |
 | `force_multiline`      | boolean | no       | false    | Always place the state on a new line below the name                                                            |
@@ -394,6 +394,7 @@ The card uses JSON-based localization.
 Available translations:
 
 - English
+- Czech
 - German
 - French
 - Italian

--- a/src/editor/general-settings.js
+++ b/src/editor/general-settings.js
@@ -64,6 +64,7 @@ class TimelineCardGeneralSettings extends LitElement {
                       mode: 'dropdown',
                       options: [
                         { value: 'auto', label: 'Auto' },
+                        { value: 'cs', label: 'Čeština' },
                         { value: 'de', label: 'Deutsch' },
                         { value: 'en-GB', label: 'English (UK)' },
                         { value: 'en-US', label: 'English (US)' },

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1,0 +1,66 @@
+{
+  "time": {
+    "seconds": "před chvílí",
+    "minutes": "před {n} min",
+    "hours": "před {n} h",
+    "days": "před {n} d"
+  },
+  "status": {
+    "locked": "zamčeno",
+    "unlocked": "odemčeno",
+    "open": "otevřeno",
+    "closed": "zavřeno",
+    "on": "zapnuto",
+    "off": "vypnuto",
+    "home": "doma",
+    "not_home": "pryč",
+    "idle": "nečinné",
+    "running": "běží",
+    "paused": "pozastaveno",
+    "stopped": "zastaveno",
+    "pending": "čeká",
+    "unknown": "neznámé",
+    "unavailable": "nedostupné",
+    "detected": "detekováno",
+    "clear": "bez detekce",
+    "online": "online",
+    "offline": "offline",
+    "playing": "přehrává se",
+    "buffering": "načítá se",
+    "standby": "pohotovost",
+    "cleaning": "uklízí",
+    "returning": "vrací se",
+    "docked": "v dokovací stanici",
+    "charging": "nabíjí se",
+    "error": "chyba",
+    "spot_cleaning": "bodový úklid",
+    "edge_cleaning": "úklid podél stěn",
+    "mopping": "vytírání",
+    "locating": "určování polohy",
+    "moving": "pohybuje se",
+    "stuck": "zaseknuto",
+    "disarmed": "deaktivováno",
+    "armed_home": "střežení doma",
+    "armed_away": "střežení mimo domov",
+    "armed_night": "noční střežení",
+    "armed_custom_bypass": "vlastní režim střežení",
+    "arming": "aktivace střežení",
+    "disarming": "deaktivace střežení",
+    "triggered": "spuštěno"
+  },
+  "ui": {
+    "show_more": "Zobrazit další {n}",
+    "show_less": "Zobrazit méně",
+    "no_events": "V tomto časovém období nejsou žádné události."
+  },
+  "date_format": {
+    "datetime": {
+      "day": "2-digit",
+      "month": "2-digit",
+      "year": "numeric",
+      "hour": "2-digit",
+      "minute": "2-digit",
+      "hour12": false
+    }
+  }
+}

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -1,3 +1,4 @@
+import cs from './locales/cs.json';
 import de from './locales/de.json';
 import enGB from './locales/en-GB.json';
 import enUS from './locales/en-US.json';
@@ -23,6 +24,7 @@ import { getCachedHistory, setCachedHistory } from './history-cache.js';
 import { transformState } from './state-transform.js';
 
 const translations = {
+  cs,
   de,
   'en-gb': enGB,
   'en-us': enUS,


### PR DESCRIPTION
## Summary

This PR adds Czech localization support to the Timeline Card.

## Changes

- Added a new Czech locale file: `src/locales/cs.json`
- Registered the new `cs` locale in the card translation setup
- Added `Čeština` to the language selector in the editor UI
- Updated the README to list Czech as a supported language

## Notes

The editor interface itself remains in English, but Czech can now be selected from the language dropdown or configured manually with `language: cs`.
