### PR TITLE
fix(ci): restore formatting and restrict workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    target-branch: "develop"
+  - package-ecosystem: 'npm'
+    directory: '/'
+    target-branch: 'develop'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "develop"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    target-branch: 'develop'
     schedule:
-      interval: "weekly"
-
-
-      
+      interval: 'weekly'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
## Summary
- format `.github/dependabot.yml` so the CI formatting gate passes
- restrict the test workflow token to `contents: read`
- resolve CodeQL alert `actions/missing-workflow-permissions`

## Verification
- `npm run lint`
- `npm run check-format`
- `npm test` (14/14)
- `npm run build`
- `git diff --check`