### PR TITLE
feat: add versioned console banner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Validate release metadata
-        run: node scripts/validate-release-version.mjs
+      - name: Validate release metadata and extract release notes
+        run: node scripts/validate-release-version.mjs --write-release-notes RELEASE_NOTES.md
 
       - name: Install dependencies
         run: npm ci
@@ -35,48 +35,7 @@ jobs:
       - name: Build timeline-card
         run: npm run build
 
-      # Extract release notes for the current tag
-      - name: Extract release notes for tag
-        id: changelog
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          echo "TAG: $TAG"
-
-          # Ensure the changelog exists
-          if [ ! -f CHANGELOG.md ]; then
-            echo "CHANGELOG.md not found"
-            exit 1
-          fi
-
-          # Find matching version section header ("## vX.Y.Z")
-          START_LINE=$(grep -nE "^##[[:space:]]+${TAG}[[:space:]]*$" CHANGELOG.md | cut -d: -f1 | head -n1 || true)
-
-          # If there's no section for this tag → fail the job
-          if [ -z "$START_LINE" ]; then
-            echo "No changelog section found for ${TAG}"
-            exit 1
-          fi
-
-          # Find next section header to determine the end of the block
-          END_LINE=$(tail -n +"$((START_LINE+1))" CHANGELOG.md | grep -n "^## " | head -n1 | cut -d: -f1 || true)
-
-          if [ -z "$END_LINE" ]; then
-            # No further header → end of file
-            END_LINE=$(wc -l < CHANGELOG.md)
-          else
-            END_LINE=$((START_LINE + END_LINE - 1))
-          fi
-
-          # Extract changelog content (excluding the header)
-          sed -n "$((START_LINE+1))","$END_LINE"p CHANGELOG.md > RELEASE_NOTES.md
-
-          # Check if extracted notes are empty
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "Release notes section for ${TAG} is empty"
-            exit 1
-          fi
-
-      # Create release only if extraction succeeded
+      # Create release only if validation and extraction succeeded
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      - name: Validate release metadata
+        run: node scripts/validate-release-version.mjs
+
       - name: Install dependencies
         run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.11.2
 
+### Added
+
+- Added a styled browser console banner showing the bundled Timeline Card version
+
 ### Fixed
 
 - Fixed `left` and `right` layouts retaining a truncated initial width when opened in dynamically sized containers such as `browser_mod.popup`
@@ -11,6 +15,10 @@
 
 - Updated the transitive development dependency `@humanfs/node` to `0.16.8` to prevent recursive copies from following symlinks outside the source tree
 - Updated the transitive development dependency `ajv` to `8.20.0` to address a regular expression denial-of-service vulnerability when using `$data`
+
+### Maintenance
+
+- Synchronized package metadata with `v1.11.2` and added release checks for matching tag, package, lockfile, and changelog versions
 
 No configuration changes are required.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timeline-card",
-  "version": "1.0.0",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timeline-card",
-      "version": "1.0.0",
+      "version": "1.11.2",
       "license": "ISC",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-card",
-  "version": "1.0.0",
+  "version": "1.11.2",
   "description": "A custom Lovelace card for Home Assistant that renders a vertical,\r alternating timeline of recent events for one or more entities.\\\r Supports per-entity configuration, localized time and state labels, icon\r mapping, and flexible filtering.",
   "main": "index.js",
   "directories": {

--- a/scripts/validate-release-version.mjs
+++ b/scripts/validate-release-version.mjs
@@ -1,6 +1,48 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+const SEMVER_SOURCE =
+  '(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)' +
+  '(?:-(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)' +
+  '(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*)?' +
+  '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?';
+const SEMVER_PATTERN = new RegExp(`^${SEMVER_SOURCE}$`);
+const RELEASE_TAG_PATTERN = new RegExp(`^v${SEMVER_SOURCE}$`);
+const PROJECT_ROOT = new URL('../', import.meta.url);
+
+export function extractReleaseNotes(changelog, tagName) {
+  const lines = changelog.split('\n');
+  const matchingSections = [];
+
+  lines.forEach((line, index) => {
+    const heading = line.match(/^##\s+(\S+)\s*$/);
+    if (heading?.[1] === tagName) matchingSections.push(index);
+  });
+
+  if (matchingSections.length === 0) {
+    throw new Error(`No changelog section found for ${tagName}`);
+  }
+  if (matchingSections.length !== 1) {
+    throw new Error(
+      `Changelog must contain exactly one section for ${tagName}`
+    );
+  }
+
+  const startIndex = matchingSections[0] + 1;
+  const relativeEndIndex = lines
+    .slice(startIndex)
+    .findIndex((line) => /^##\s+/.test(line));
+  const endIndex =
+    relativeEndIndex === -1 ? lines.length : startIndex + relativeEndIndex;
+  const notes = lines.slice(startIndex, endIndex).join('\n').trim();
+
+  if (!notes) {
+    throw new Error(`Release notes section for ${tagName} is empty`);
+  }
+
+  return `${notes}\n`;
+}
 
 export function validateReleaseMetadata({
   tagName,
@@ -9,8 +51,29 @@ export function validateReleaseMetadata({
   lockRootVersion,
   changelog,
 }) {
-  const tagVersion = tagName?.startsWith('v') ? tagName.slice(1) : tagName;
   const errors = [];
+  const tagIsValid =
+    typeof tagName === 'string' && RELEASE_TAG_PATTERN.test(tagName);
+  const tagVersion =
+    typeof tagName === 'string' && tagName.startsWith('v')
+      ? tagName.slice(1)
+      : tagName;
+
+  if (!tagIsValid) {
+    errors.push(`Release tag ${tagName} must match v<SemVer>`);
+  }
+
+  [
+    ['package.json version', packageVersion],
+    ['package-lock.json version', lockfileVersion],
+    ['package-lock.json root version', lockRootVersion],
+  ].forEach(([label, version]) => {
+    if (typeof version !== 'string' || !SEMVER_PATTERN.test(version)) {
+      errors.push(
+        `${label} ${version} must be valid SemVer without a v prefix`
+      );
+    }
+  });
 
   if (tagVersion !== packageVersion) {
     errors.push(
@@ -24,21 +87,26 @@ export function validateReleaseMetadata({
     );
   }
 
-  const escapedVersion = tagVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const changelogHeading = new RegExp(`^##\\s+v${escapedVersion}\\s*$`, 'm');
-  if (!changelogHeading.test(changelog)) {
-    errors.push(`No changelog section found for v${tagVersion}`);
+  try {
+    extractReleaseNotes(changelog, tagName);
+  } catch (error) {
+    errors.push(error.message);
   }
 
   return errors;
 }
 
 function validateCurrentRelease() {
-  const packageMetadata = JSON.parse(readFileSync('package.json', 'utf8'));
-  const lockMetadata = JSON.parse(readFileSync('package-lock.json', 'utf8'));
-  const changelog = readFileSync('CHANGELOG.md', 'utf8');
+  const packageMetadata = JSON.parse(
+    readFileSync(new URL('package.json', PROJECT_ROOT), 'utf8')
+  );
+  const lockMetadata = JSON.parse(
+    readFileSync(new URL('package-lock.json', PROJECT_ROOT), 'utf8')
+  );
+  const changelog = readFileSync(new URL('CHANGELOG.md', PROJECT_ROOT), 'utf8');
+  const tagName = process.env.GITHUB_REF_NAME;
   const errors = validateReleaseMetadata({
-    tagName: process.env.GITHUB_REF_NAME,
+    tagName,
     packageVersion: packageMetadata.version,
     lockfileVersion: lockMetadata.version,
     lockRootVersion: lockMetadata.packages[''].version,
@@ -51,10 +119,25 @@ function validateCurrentRelease() {
     return;
   }
 
-  console.log(`Release metadata matches ${process.env.GITHUB_REF_NAME}`);
+  const outputOptionIndex = process.argv.indexOf('--write-release-notes');
+  if (outputOptionIndex !== -1) {
+    const outputPath = process.argv[outputOptionIndex + 1];
+    if (!outputPath) {
+      console.error('::error::--write-release-notes requires a file path');
+      process.exitCode = 1;
+      return;
+    }
+    writeFileSync(
+      resolve(outputPath),
+      extractReleaseNotes(changelog, tagName),
+      'utf8'
+    );
+  }
+
+  console.log(`Release metadata matches ${tagName}`);
 }
 
+const scriptPath = fileURLToPath(import.meta.url);
 const isMainModule =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+  process.argv[1] && realpathSync(scriptPath) === realpathSync(process.argv[1]);
 if (isMainModule) validateCurrentRelease();

--- a/scripts/validate-release-version.mjs
+++ b/scripts/validate-release-version.mjs
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function validateReleaseMetadata({
+  tagName,
+  packageVersion,
+  lockfileVersion,
+  lockRootVersion,
+  changelog,
+}) {
+  const tagVersion = tagName?.startsWith('v') ? tagName.slice(1) : tagName;
+  const errors = [];
+
+  if (tagVersion !== packageVersion) {
+    errors.push(
+      `Tag version ${tagVersion} does not match package.json version ${packageVersion}`
+    );
+  }
+
+  if (tagVersion !== lockfileVersion || tagVersion !== lockRootVersion) {
+    errors.push(
+      `Tag version ${tagVersion} does not match package-lock.json versions ${lockfileVersion}/${lockRootVersion}`
+    );
+  }
+
+  const escapedVersion = tagVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const changelogHeading = new RegExp(`^##\\s+v${escapedVersion}\\s*$`, 'm');
+  if (!changelogHeading.test(changelog)) {
+    errors.push(`No changelog section found for v${tagVersion}`);
+  }
+
+  return errors;
+}
+
+function validateCurrentRelease() {
+  const packageMetadata = JSON.parse(readFileSync('package.json', 'utf8'));
+  const lockMetadata = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+  const changelog = readFileSync('CHANGELOG.md', 'utf8');
+  const errors = validateReleaseMetadata({
+    tagName: process.env.GITHUB_REF_NAME,
+    packageVersion: packageMetadata.version,
+    lockfileVersion: lockMetadata.version,
+    lockRootVersion: lockMetadata.packages[''].version,
+    changelog,
+  });
+
+  if (errors.length) {
+    errors.forEach((error) => console.error(`::error::${error}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Release metadata matches ${process.env.GITHUB_REF_NAME}`);
+}
+
+const isMainModule =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMainModule) validateCurrentRelease();

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -10,6 +10,7 @@ import ptBR from './locales/pt-BR.json';
 import ru from './locales/ru.json';
 import sv from './locales/sv.json';
 import styles from './timeline-card.css';
+import packageMetadata from '../package.json';
 
 import './editor/timeline-card-editor.js';
 
@@ -39,6 +40,12 @@ const translations = {
   ru,
   sv,
 };
+
+console.info(
+  `%c TIMELINE-CARD %c v${packageMetadata.version} `,
+  'background:#2da8ff;color:#fff;padding:4px 7px;font-weight:700;border-radius:4px 0 0 4px',
+  'background:#b24aff;color:#fff;padding:4px 7px;font-weight:700;border-radius:0 4px 4px 0'
+);
 
 class TimelineCard extends HTMLElement {
   static getConfigElement() {

--- a/tests/release-version.test.js
+++ b/tests/release-version.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { validateReleaseMetadata } from '../scripts/validate-release-version.mjs';
+
+const packageMetadata = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+);
+const lockMetadata = JSON.parse(
+  readFileSync(new URL('../package-lock.json', import.meta.url), 'utf8')
+);
+const changelog = readFileSync(
+  new URL('../CHANGELOG.md', import.meta.url),
+  'utf8'
+);
+
+describe('release version metadata', () => {
+  it('keeps package, lockfile, and latest changelog versions aligned', () => {
+    const latestChangelogVersion = changelog.match(/^## v([^\s]+)$/m)?.[1];
+
+    expect(latestChangelogVersion).toBeDefined();
+    expect(packageMetadata.version).toBe(latestChangelogVersion);
+    expect(lockMetadata.version).toBe(latestChangelogVersion);
+    expect(lockMetadata.packages[''].version).toBe(latestChangelogVersion);
+  });
+
+  it('accepts matching release metadata', () => {
+    expect(
+      validateReleaseMetadata({
+        tagName: 'v1.11.2',
+        packageVersion: '1.11.2',
+        lockfileVersion: '1.11.2',
+        lockRootVersion: '1.11.2',
+        changelog: '## v1.11.2\n\nRelease notes',
+      })
+    ).toEqual([]);
+  });
+
+  it('rejects mismatched tags and missing changelog sections', () => {
+    expect(
+      validateReleaseMetadata({
+        tagName: 'v1.11.3',
+        packageVersion: '1.11.2',
+        lockfileVersion: '1.11.2',
+        lockRootVersion: '1.11.2',
+        changelog: '## v1.11.2\n\nRelease notes',
+      })
+    ).toEqual([
+      'Tag version 1.11.3 does not match package.json version 1.11.2',
+      'Tag version 1.11.3 does not match package-lock.json versions 1.11.2/1.11.2',
+      'No changelog section found for v1.11.3',
+    ]);
+  });
+});

--- a/tests/release-version.test.js
+++ b/tests/release-version.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { validateReleaseMetadata } from '../scripts/validate-release-version.mjs';
+import {
+  extractReleaseNotes,
+  validateReleaseMetadata,
+} from '../scripts/validate-release-version.mjs';
 
 const packageMetadata = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8')
@@ -49,5 +52,60 @@ describe('release version metadata', () => {
       'Tag version 1.11.3 does not match package-lock.json versions 1.11.2/1.11.2',
       'No changelog section found for v1.11.3',
     ]);
+  });
+
+  it.each(['vbanana', 'vv1.2.3', '1.2.3'])(
+    'rejects malformed release tag %s',
+    (tagName) => {
+      expect(
+        validateReleaseMetadata({
+          tagName,
+          packageVersion: '1.2.3',
+          lockfileVersion: '1.2.3',
+          lockRootVersion: '1.2.3',
+          changelog: '## v1.2.3\n\nRelease notes',
+        })
+      ).toContain(`Release tag ${tagName} must match v<SemVer>`);
+    }
+  );
+
+  it('rejects malformed package and lockfile versions', () => {
+    expect(
+      validateReleaseMetadata({
+        tagName: 'v1.2.3',
+        packageVersion: 'v1.2.3',
+        lockfileVersion: 'banana',
+        lockRootVersion: '01.2.3',
+        changelog: '## v1.2.3\n\nRelease notes',
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        'package.json version v1.2.3 must be valid SemVer without a v prefix',
+        'package-lock.json version banana must be valid SemVer without a v prefix',
+        'package-lock.json root version 01.2.3 must be valid SemVer without a v prefix',
+      ])
+    );
+  });
+
+  it('extracts the exact tag section instead of a regex-like heading', () => {
+    const notes = extractReleaseNotes(
+      '## v1x11x2\n\nWrong notes\n\n## v1.11.2\n\nCorrect notes\n\n## v1.11.1\n\nOlder notes\n',
+      'v1.11.2'
+    );
+
+    expect(notes).toBe('Correct notes\n');
+  });
+
+  it('rejects duplicate and whitespace-only release-note sections', () => {
+    expect(() =>
+      extractReleaseNotes(
+        '## v1.11.2\n \n\t\n## v1.11.2\n\nActual notes\n',
+        'v1.11.2'
+      )
+    ).toThrow('Changelog must contain exactly one section for v1.11.2');
+
+    expect(() => extractReleaseNotes('## v1.11.2\n \n\t\n', 'v1.11.2')).toThrow(
+      'Release notes section for v1.11.2 is empty'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add a styled `TIMELINE-CARD` browser console banner with the bundled version
- align `package.json` and lockfile metadata with `v1.11.2`
- validate release tag, package metadata, lockfile metadata, and changelog before publishing
- add regression tests for matching and mismatched release metadata

## Verification

- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run check-format`
- `npm test` — 17 tests passed
- `npm run build`
- `npm audit --json` — 0 vulnerabilities
- positive release validation with `GITHUB_REF_NAME=v1.11.2`
- negative release validation with `GITHUB_REF_NAME=v1.11.3`
- Chromium/CDP smoke test confirmed exactly one styled `console.info` banner with `v1.11.2`

## Notes

Creating a `v*` tag remains the release trigger. The release now fails before dependency installation if tag, package metadata, lockfile metadata, or changelog disagree.
