### PR TITLE
feat: add entity card suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.12.0
+
+### Added
+
+- Added Timeline Card suggestions with the selected entity to Home Assistant's entity-first card picker
+
+No configuration changes are required.
+
 ## v1.11.2
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timeline-card",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timeline-card",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "ISC",
       "dependencies": {
         "lit": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeline-card",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "A custom Lovelace card for Home Assistant that renders a vertical,\r alternating timeline of recent events for one or more entities.\\\r Supports per-entity configuration, localized time and state labels, icon\r mapping, and flexible filtering.",
   "main": "index.js",
   "directories": {

--- a/src/card-picker.js
+++ b/src/card-picker.js
@@ -1,0 +1,46 @@
+const ACTION_ONLY_DOMAINS = new Set([
+  'button',
+  'input_button',
+  'scene',
+  'script',
+]);
+
+export function createTimelineConfig(entityIds, { includeType = false } = {}) {
+  return {
+    ...(includeType ? { type: 'custom:timeline-card' } : {}),
+    title: 'Timeline',
+    hours: 6,
+    limit: 10,
+    relative_time: true,
+    show_names: true,
+    show_states: true,
+    show_icons: true,
+    entities: entityIds.map((entity) => ({ entity })),
+  };
+}
+
+export function isTimelineEntitySupported(hass, entityId) {
+  if (!hass?.states || typeof entityId !== 'string') return false;
+
+  const separatorIndex = entityId.indexOf('.');
+  if (
+    separatorIndex <= 0 ||
+    separatorIndex === entityId.length - 1 ||
+    entityId.indexOf('.', separatorIndex + 1) !== -1
+  ) {
+    return false;
+  }
+
+  const domain = entityId.slice(0, separatorIndex);
+  return (
+    Object.hasOwn(hass.states, entityId) && !ACTION_ONLY_DOMAINS.has(domain)
+  );
+}
+
+export function createEntitySuggestion(hass, entityId) {
+  if (!isTimelineEntitySupported(hass, entityId)) return null;
+
+  return {
+    config: createTimelineConfig([entityId], { includeType: true }),
+  };
+}

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -26,6 +26,7 @@ import { getCachedHistory, setCachedHistory } from './history-cache.js';
 // Unified state transformer for both history + live
 import { transformState } from './state-transform.js';
 import { resolveStateMappedColor } from './color-engine.js';
+import { createEntitySuggestion } from './card-picker.js';
 
 const translations = {
   cs,
@@ -737,4 +738,5 @@ window.customCards.push({
   name: 'Timeline Card',
   description:
     'A timeline-based event history card with icons, states and WS updates.',
+  getEntitySuggestion: createEntitySuggestion,
 });

--- a/tests/card-picker.test.js
+++ b/tests/card-picker.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEntitySuggestion,
+  isTimelineEntitySupported,
+} from '../src/card-picker.js';
+
+const createHass = (...entityIds) => ({
+  states: Object.fromEntries(
+    entityIds.map((entity_id) => [entity_id, { entity_id, state: 'on' }])
+  ),
+});
+
+describe('Timeline Card entity suggestions', () => {
+  it('creates a complete config using only the selected entity', () => {
+    const hass = createHass('binary_sensor.front_door', 'person.tobi');
+
+    expect(createEntitySuggestion(hass, 'binary_sensor.front_door')).toEqual({
+      config: {
+        type: 'custom:timeline-card',
+        title: 'Timeline',
+        hours: 6,
+        limit: 10,
+        relative_time: true,
+        show_names: true,
+        show_states: true,
+        show_icons: true,
+        entities: [{ entity: 'binary_sensor.front_door' }],
+      },
+    });
+  });
+
+  it.each([
+    'button.restart',
+    'input_button.doorbell',
+    'scene.evening',
+    'script.good_night',
+  ])('does not suggest a timeline for action-only entity %s', (entityId) => {
+    const hass = createHass(entityId);
+
+    expect(isTimelineEntitySupported(hass, entityId)).toBe(false);
+    expect(createEntitySuggestion(hass, entityId)).toBeNull();
+  });
+
+  it('does not suggest a timeline for a missing or malformed entity', () => {
+    const hass = createHass('sensor.temperature');
+
+    expect(createEntitySuggestion(hass, 'sensor.missing')).toBeNull();
+    expect(createEntitySuggestion(hass, 'malformed')).toBeNull();
+    expect(createEntitySuggestion(undefined, 'sensor.temperature')).toBeNull();
+  });
+
+  it.each([
+    'sensor.temperature',
+    'binary_sensor.front_door',
+    'person.tobi',
+    'light.kitchen',
+    'automation.arrival',
+  ])('supports stateful entity %s', (entityId) => {
+    const hass = createHass(entityId);
+
+    expect(isTimelineEntitySupported(hass, entityId)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add Timeline Card to Home Assistant's entity-first card picker
- create a ready-to-use configuration containing exactly the selected entity
- exclude action-only entity domains where a state timeline is not useful
- bump package and release metadata to `v1.12.0`

## Compatibility

Entity suggestions require Home Assistant 2026.6 or newer. Existing Timeline Card configurations and the general card-picker entry remain unchanged.

## Verification

- 34 tests passed
- ESLint passed
- Prettier passed
- production build passed
- release metadata validation passed for `v1.12.0`
- npm audit reported 0 vulnerabilities
- Chromium bundle test confirmed registration, selected-entity propagation, excluded-domain behavior, and no general picker preview
