### PR TITLE
feat: add live card picker preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Timeline Card suggestions with the selected entity to Home Assistant's entity-first card picker
+- Added a live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance
 
 No configuration changes are required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added Timeline Card suggestions with the selected entity to Home Assistant's entity-first card picker
-- Added a compact one-sided live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance
+- Added a compact one-sided live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance, while keeping recorder-backed history active in card-editor previews
 
 No configuration changes are required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added Timeline Card suggestions with the selected entity to Home Assistant's entity-first card picker
-- Added a live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance
+- Added a compact one-sided live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance
 
 No configuration changes are required.
 

--- a/src/card-picker.js
+++ b/src/card-picker.js
@@ -72,8 +72,22 @@ export function createPreviewConfig(hass, entities, entitiesFallback) {
   );
 }
 
-export function isGeneralCardPickerPreview(element) {
-  return element?.getRootNode?.()?.host?.localName === 'hui-card-picker';
+const CARD_PICKER_HOSTS = new Set(['hui-card-picker', 'hui-suggestion-picker']);
+
+export function isCardPickerPreview(element) {
+  const visited = new Set();
+  let current = element;
+
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    if (CARD_PICKER_HOSTS.has(current.localName)) return true;
+
+    const shadowHost = current.getRootNode?.()?.host;
+    current =
+      shadowHost && shadowHost !== current ? shadowHost : current.parentElement;
+  }
+
+  return false;
 }
 
 export function getEffectiveTimelineLayout(configuredLayout, previewMode) {

--- a/src/card-picker.js
+++ b/src/card-picker.js
@@ -44,3 +44,34 @@ export function createEntitySuggestion(hass, entityId) {
     config: createTimelineConfig([entityId], { includeType: true }),
   };
 }
+
+export function selectPreviewEntities(
+  hass,
+  entities = [],
+  entitiesFallback = [],
+  maxEntities = 3
+) {
+  const candidates = [
+    ...(Array.isArray(entities) ? entities : []),
+    ...(Array.isArray(entitiesFallback) ? entitiesFallback : []),
+    ...Object.keys(hass?.states || {}),
+  ];
+
+  return [...new Set(candidates)]
+    .filter(
+      (entityId) =>
+        isTimelineEntitySupported(hass, entityId) &&
+        hass.entities?.[entityId]?.hidden !== true
+    )
+    .slice(0, maxEntities);
+}
+
+export function createPreviewConfig(hass, entities, entitiesFallback) {
+  return createTimelineConfig(
+    selectPreviewEntities(hass, entities, entitiesFallback)
+  );
+}
+
+export function isGeneralCardPickerPreview(element) {
+  return element?.getRootNode?.()?.host?.localName === 'hui-card-picker';
+}

--- a/src/card-picker.js
+++ b/src/card-picker.js
@@ -75,3 +75,10 @@ export function createPreviewConfig(hass, entities, entitiesFallback) {
 export function isGeneralCardPickerPreview(element) {
   return element?.getRootNode?.()?.host?.localName === 'hui-card-picker';
 }
+
+export function getEffectiveTimelineLayout(configuredLayout, previewMode) {
+  if (previewMode) return 'left';
+  return ['center', 'left', 'right'].includes(configuredLayout)
+    ? configuredLayout
+    : 'center';
+}

--- a/src/history-fetch.js
+++ b/src/history-fetch.js
@@ -7,6 +7,8 @@ export async function fetchHistory(hass, entities, hours) {
 
   const entityParam = entities.map((e) => e.entity).join(',');
 
+  if (!entityParam) return { data: [], start };
+
   const data = await hass.callApi(
     'GET',
     `history/period/${startTime}?filter_entity_id=${entityParam}&end_time=${endTime}`

--- a/src/live-subscription.js
+++ b/src/live-subscription.js
@@ -1,0 +1,54 @@
+export function createLiveSubscription(connection, callback) {
+  let stopRequested = false;
+  let unsubscribeStarted = false;
+  let setupFailed = false;
+  let unsubscribe = null;
+  let resolveStopped;
+  const stopped = new Promise((resolve) => {
+    resolveStopped = resolve;
+  });
+
+  const performUnsubscribe = () => {
+    if (unsubscribeStarted) return;
+    unsubscribeStarted = true;
+
+    let unsubscribeResult;
+    try {
+      unsubscribeResult =
+        typeof unsubscribe === 'function' ? unsubscribe() : undefined;
+    } catch {
+      unsubscribeResult = undefined;
+    }
+
+    Promise.resolve(unsubscribeResult)
+      .catch(() => undefined)
+      .then(() => {
+        unsubscribe = null;
+        resolveStopped();
+      });
+  };
+
+  const ready = Promise.resolve()
+    .then(() => connection.subscribeEvents(callback, 'state_changed'))
+    .then((unsubscribeCallback) => {
+      unsubscribe = unsubscribeCallback;
+      if (stopRequested) performUnsubscribe();
+    })
+    .catch((error) => {
+      setupFailed = true;
+      if (stopRequested) resolveStopped();
+      throw error;
+    });
+
+  return {
+    ready,
+    stop() {
+      if (!stopRequested) {
+        stopRequested = true;
+        if (setupFailed) resolveStopped();
+        else if (unsubscribe !== null) performUnsubscribe();
+      }
+      return stopped;
+    },
+  };
+}

--- a/src/preview-items.js
+++ b/src/preview-items.js
@@ -1,0 +1,12 @@
+import { filterHistory } from './history-filter.js';
+import { transformState } from './state-transform.js';
+
+export function createCurrentStatePreview(hass, entities, i18n, limit, config) {
+  const items = entities
+    .map(({ entity }) =>
+      transformState(entity, hass.states[entity], hass, entities, i18n)
+    )
+    .filter(Boolean);
+
+  return filterHistory(items, entities, limit, config);
+}

--- a/src/timeline-card.css
+++ b/src/timeline-card.css
@@ -46,6 +46,22 @@ ha-card {
   margin: 0 auto;
 }
 
+.wrapper.picker-preview.layout-left {
+  --tc-line-column: 28px;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  direction: ltr;
+}
+
+.wrapper.picker-preview.layout-left .event-box {
+  direction: ltr;
+}
+
+:host(:dir(rtl)) .wrapper.picker-preview.layout-left .event-box {
+  direction: rtl;
+}
+
 .wrapper.compact {
   padding-top: 7px;
   padding-bottom: 5px;
@@ -107,6 +123,13 @@ ha-card {
     var(--tc-line-column);
 }
 
+.wrapper.picker-preview.layout-left .timeline-row {
+  grid-template-columns: var(--tc-line-column) minmax(0, 1fr);
+  width: 100%;
+  margin: 6px 0;
+  column-gap: 8px;
+}
+
 .side {
   width: 47%;
   display: flex;
@@ -147,6 +170,22 @@ ha-card {
 .wrapper.layout-right .event-box {
   width: 100%;
   box-sizing: border-box;
+}
+
+.wrapper.picker-preview .event-box {
+  padding: 7px 9px;
+  gap: 8px;
+}
+
+.wrapper.picker-preview .text {
+  flex: 1;
+  overflow: hidden;
+}
+
+.wrapper.picker-preview .time {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .event-box {

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -26,7 +26,13 @@ import { getCachedHistory, setCachedHistory } from './history-cache.js';
 // Unified state transformer for both history + live
 import { transformState } from './state-transform.js';
 import { resolveStateMappedColor } from './color-engine.js';
-import { createEntitySuggestion } from './card-picker.js';
+import {
+  createEntitySuggestion,
+  createPreviewConfig,
+  isGeneralCardPickerPreview,
+} from './card-picker.js';
+import { createLiveSubscription } from './live-subscription.js';
+import { createCurrentStatePreview } from './preview-items.js';
 
 const translations = {
   cs,
@@ -53,18 +59,8 @@ class TimelineCard extends HTMLElement {
     return document.createElement('weedpump-timeline-card-editor');
   }
 
-  static getStubConfig() {
-    return {
-      type: 'custom:timeline-card',
-      title: 'Timeline',
-      hours: 6,
-      limit: 10,
-      relative_time: true,
-      show_names: true,
-      show_states: true,
-      show_icons: true,
-      entities: [],
-    };
+  static getStubConfig(hass, entities, entitiesFallback) {
+    return createPreviewConfig(hass, entities, entitiesFallback);
   }
 
   setConfig(config) {
@@ -145,6 +141,7 @@ class TimelineCard extends HTMLElement {
     this.expanded = false;
 
     this.refreshInterval = config.refresh_interval || null;
+    if (this.refreshTimer) clearInterval(this.refreshTimer);
     this.refreshTimer = null;
     this.singleSideResizeObserver?.disconnect();
     this.singleSideResizeObserver = null;
@@ -152,7 +149,11 @@ class TimelineCard extends HTMLElement {
     this.singleSideLayout = null;
     this.singleSideSignature = null;
 
-    this.liveUnsub = null;
+    this.liveSubscription?.stop();
+    this.liveSubscription = null;
+    this.configGeneration = (this.configGeneration || 0) + 1;
+    this.dataGeneration = (this.dataGeneration || 0) + 1;
+    this.i18nReady = false;
 
     this.items = [];
     this.loaded = false;
@@ -171,6 +172,55 @@ class TimelineCard extends HTMLElement {
     if (this.loaded && this.items?.length && this.cardLayout !== 'center') {
       this.applySingleSideWidth(this.shadowRoot, this.cardLayout);
     }
+
+    const wasPreview = this.isPreviewMode();
+    this.pickerPreview = isGeneralCardPickerPreview(this);
+    const modeChanged = this.handlePreviewModeChange(wasPreview);
+
+    if (!modeChanged && this.loaded && this.i18nReady) {
+      this.applyCurrentMode();
+    }
+    queueMicrotask(() => this.startLiveEventsIfNeeded());
+  }
+
+  set preview(value) {
+    const wasPreview = this.isPreviewMode();
+    this._preview = value === true;
+    this.handlePreviewModeChange(wasPreview);
+  }
+
+  get preview() {
+    return this._preview === true;
+  }
+
+  isPreviewMode() {
+    return this._preview === true || this.pickerPreview === true;
+  }
+
+  handlePreviewModeChange(wasPreview) {
+    const isPreview = this.isPreviewMode();
+    if (wasPreview === isPreview) return false;
+
+    this.dataGeneration = (this.dataGeneration || 0) + 1;
+    this.liveSubscription?.stop();
+    this.liveSubscription = null;
+
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+
+    if (!this.loaded || !this.i18nReady) return true;
+
+    if (isPreview) {
+      this.loadPreview();
+    } else {
+      this.items = [];
+      this.render();
+      this.startNormalMode();
+    }
+
+    return true;
   }
 
   ensureCardExists() {
@@ -209,28 +259,78 @@ class TimelineCard extends HTMLElement {
       const yamlLang = this.config.language;
       const haLang = hass?.locale?.language;
       const browserLang = navigator.language;
+      const configGeneration = this.configGeneration;
 
       this.language = yamlLang || haLang || browserLang || 'en-US';
-
       this.i18n = new TranslationEngine(translations);
 
       this.i18n.load(this.language).then(() => {
+        if (configGeneration !== this.configGeneration) return;
+
         // Keep the full normalized language code so region-specific formats work.
         this.languageCode = this.i18n.langCode || this.language.toLowerCase();
-        this.loadHistory();
-
-        if (this.refreshInterval && !this.refreshTimer) {
-          this.startAutoRefresh();
+        this.i18nReady = true;
+        if (this.isConnected) this.applyCurrentMode();
+      });
+    } else if (this.isPreviewMode() && this.i18nReady) {
+      queueMicrotask(() => {
+        if (
+          this.isConnected &&
+          this.isPreviewMode() &&
+          this.hassInst === hass
+        ) {
+          this.loadPreview();
         }
       });
     }
 
-    if (this.hassInst?.connection && !this.liveUnsub) {
-      this.startLiveEvents();
+    queueMicrotask(() => {
+      if (this.hassInst === hass) this.startLiveEventsIfNeeded();
+    });
+  }
+
+  applyCurrentMode() {
+    if (this.isPreviewMode()) {
+      this.loadPreview();
+    } else {
+      this.startNormalMode();
     }
   }
 
-  async loadHistory() {
+  startNormalMode() {
+    if (
+      this.isPreviewMode() ||
+      !this.isConnected ||
+      !this.i18nReady ||
+      !this.hassInst
+    ) {
+      return;
+    }
+
+    const generation = this.dataGeneration;
+    this.loadHistory(generation).catch(() => undefined);
+
+    if (this.refreshInterval && !this.refreshTimer) {
+      this.startAutoRefresh();
+    }
+
+    queueMicrotask(() => this.startLiveEventsIfNeeded());
+  }
+
+  loadPreview() {
+    this.items = createCurrentStatePreview(
+      this.hassInst,
+      this.entities,
+      this.i18n,
+      this.limit,
+      this.config
+    );
+    this.render();
+  }
+
+  async loadHistory(generation = this.dataGeneration) {
+    if (this.isPreviewMode() || generation !== this.dataGeneration) return;
+
     const cached = getCachedHistory(
       this.entities,
       this.hours,
@@ -238,17 +338,19 @@ class TimelineCard extends HTMLElement {
     );
 
     if (cached) {
+      if (this.isPreviewMode() || generation !== this.dataGeneration) return;
       this.items = cached;
       this.render();
-      this.refreshInBackground();
+      this.refreshInBackground(generation).catch(() => undefined);
       return;
     }
 
-    await this.refreshInForeground();
+    await this.refreshInForeground(generation);
   }
 
-  async refreshInForeground() {
+  async refreshInForeground(generation = this.dataGeneration) {
     const raw = await fetchHistory(this.hassInst, this.entities, this.hours);
+    if (this.isPreviewMode() || generation !== this.dataGeneration) return;
 
     const flat = transformHistory(
       raw,
@@ -264,14 +366,16 @@ class TimelineCard extends HTMLElement {
       this.config // includes collapse_duplicates
     );
 
+    if (this.isPreviewMode() || generation !== this.dataGeneration) return;
     setCachedHistory(this.entities, this.hours, this.languageCode, items);
 
     this.items = items;
     this.render();
   }
 
-  async refreshInBackground() {
+  async refreshInBackground(generation = this.dataGeneration) {
     const raw = await fetchHistory(this.hassInst, this.entities, this.hours);
+    if (this.isPreviewMode() || generation !== this.dataGeneration) return;
 
     const flat = transformHistory(
       raw,
@@ -287,6 +391,7 @@ class TimelineCard extends HTMLElement {
       this.config // includes collapse_duplicates
     );
 
+    if (this.isPreviewMode() || generation !== this.dataGeneration) return;
     if (JSON.stringify(items) === JSON.stringify(this.items)) return;
 
     setCachedHistory(this.entities, this.hours, this.languageCode, items);
@@ -296,23 +401,52 @@ class TimelineCard extends HTMLElement {
   }
 
   startAutoRefresh() {
+    if (this.isPreviewMode()) return;
     if (this.refreshTimer) clearInterval(this.refreshTimer);
 
     this.refreshTimer = setInterval(() => {
-      this.refreshInBackground();
+      const generation = this.dataGeneration;
+      this.refreshInBackground(generation).catch(() => undefined);
     }, this.refreshInterval * 1000);
   }
 
-  startLiveEvents() {
+  startLiveEventsIfNeeded() {
+    if (
+      this.isPreviewMode() ||
+      !this.isConnected ||
+      !this.hassInst?.connection ||
+      this.liveSubscription
+    ) {
+      return;
+    }
+
     const entityIds = this.entities.map((e) => e.entity);
+    const generation = this.dataGeneration;
+    const subscription = createLiveSubscription(
+      this.hassInst.connection,
+      (msg) => {
+        if (
+          this.isPreviewMode() ||
+          generation !== this.dataGeneration ||
+          this.liveSubscription !== subscription
+        ) {
+          return;
+        }
 
-    this.liveUnsub = this.hassInst.connection.subscribeEvents((msg) => {
-      const data = msg?.data;
-      if (!data?.entity_id) return;
-      if (!entityIds.includes(data.entity_id)) return;
+        const data = msg?.data;
+        if (!data?.entity_id) return;
+        if (!entityIds.includes(data.entity_id)) return;
 
-      this.processLiveEvent(data);
-    }, 'state_changed');
+        this.processLiveEvent(data);
+      }
+    );
+
+    this.liveSubscription = subscription;
+    subscription.ready.catch(() => {
+      if (this.liveSubscription === subscription) {
+        this.liveSubscription = null;
+      }
+    });
   }
 
   processLiveEvent(data) {
@@ -374,14 +508,13 @@ class TimelineCard extends HTMLElement {
   }
 
   disconnectedCallback() {
+    this.dataGeneration = (this.dataGeneration || 0) + 1;
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
-    if (typeof this.liveUnsub === 'function') {
-      this.liveUnsub();
-    }
-    this.liveUnsub = null;
+    this.liveSubscription?.stop();
+    this.liveSubscription = null;
     this.singleSideResizeObserver?.disconnect();
     this.singleSideResizeObserver = null;
   }
@@ -736,6 +869,7 @@ window.customCards = window.customCards || [];
 window.customCards.push({
   type: 'timeline-card',
   name: 'Timeline Card',
+  preview: true,
   description:
     'A timeline-based event history card with icons, states and WS updates.',
   getEntitySuggestion: createEntitySuggestion,

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -30,7 +30,7 @@ import {
   createEntitySuggestion,
   createPreviewConfig,
   getEffectiveTimelineLayout,
-  isGeneralCardPickerPreview,
+  isCardPickerPreview,
 } from './card-picker.js';
 import { createLiveSubscription } from './live-subscription.js';
 import { createCurrentStatePreview } from './preview-items.js';
@@ -175,7 +175,7 @@ class TimelineCard extends HTMLElement {
     }
 
     const wasPreview = this.isPreviewMode();
-    this.pickerPreview = isGeneralCardPickerPreview(this);
+    this.pickerPreview = isCardPickerPreview(this);
     const modeChanged = this.handlePreviewModeChange(wasPreview);
 
     if (!modeChanged && this.loaded && this.i18nReady) {
@@ -195,7 +195,7 @@ class TimelineCard extends HTMLElement {
   }
 
   isPreviewMode() {
-    return this._preview === true || this.pickerPreview === true;
+    return this.pickerPreview === true;
   }
 
   handlePreviewModeChange(wasPreview) {

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -29,6 +29,7 @@ import { resolveStateMappedColor } from './color-engine.js';
 import {
   createEntitySuggestion,
   createPreviewConfig,
+  getEffectiveTimelineLayout,
   isGeneralCardPickerPreview,
 } from './card-picker.js';
 import { createLiveSubscription } from './live-subscription.js';
@@ -588,10 +589,9 @@ class TimelineCard extends HTMLElement {
       ? this.items.slice(0, visibleLimit)
       : this.items;
 
-    const layout =
-      ['center', 'left', 'right'].includes(this.cardLayout) && this.cardLayout
-        ? this.cardLayout
-        : 'center';
+    const previewMode = this.isPreviewMode();
+    const layout = getEffectiveTimelineLayout(this.cardLayout, previewMode);
+    const previewClass = previewMode ? 'picker-preview' : '';
     const compactClass =
       this.compactLayout && layout === 'center' ? 'compact' : '';
 
@@ -715,7 +715,7 @@ class TimelineCard extends HTMLElement {
         <div class="timeline-container ${
           overflowMode === 'scroll' ? 'scrollable' : ''
         }" style="${containerStyle}">
-          <div class="wrapper ${compactClass} layout-${layout}">
+          <div class="wrapper ${compactClass} ${previewClass} layout-${layout}">
             <div class="timeline-line"></div>
             ${rows}
           </div>
@@ -754,6 +754,16 @@ class TimelineCard extends HTMLElement {
   applySingleSideWidth(root, layout) {
     this.singleSideResizeObserver?.disconnect();
     this.singleSideResizeObserver = null;
+
+    if (this.isPreviewMode()) {
+      this.singleSideWidth = null;
+      this.singleSideLayout = null;
+      this.singleSideSignature = null;
+      root
+        .querySelector('.wrapper')
+        ?.style.removeProperty('--tc-event-col-width');
+      return;
+    }
 
     if (layout === 'center') {
       this.singleSideWidth = null;

--- a/tests/card-picker.test.js
+++ b/tests/card-picker.test.js
@@ -3,7 +3,7 @@ import {
   createEntitySuggestion,
   createPreviewConfig,
   getEffectiveTimelineLayout,
-  isGeneralCardPickerPreview,
+  isCardPickerPreview,
   isTimelineEntitySupported,
   selectPreviewEntities,
 } from '../src/card-picker.js';
@@ -140,18 +140,38 @@ describe('Timeline Card picker preview', () => {
     expect(createPreviewConfig(hass, [], []).entities).toEqual([]);
   });
 
-  it('detects only the general card picker shadow-root context', () => {
+  it('detects direct and nested card picker shadow-root contexts', () => {
     expect(
-      isGeneralCardPickerPreview({
+      isCardPickerPreview({
         getRootNode: () => ({ host: { localName: 'hui-card-picker' } }),
       })
     ).toBe(true);
+
+    const suggestionPicker = { localName: 'hui-suggestion-picker' };
+    const suggestionCard = {
+      localName: 'hui-suggestion-card',
+      getRootNode: () => ({ host: suggestionPicker }),
+    };
     expect(
-      isGeneralCardPickerPreview({
-        getRootNode: () => ({ host: { localName: 'hui-card' } }),
+      isCardPickerPreview({
+        getRootNode: () => ({ host: suggestionCard }),
+      })
+    ).toBe(true);
+  });
+
+  it('does not treat the card editor preview as a picker preview', () => {
+    expect(
+      isCardPickerPreview({
+        preview: true,
+        getRootNode: () => ({
+          host: {
+            localName: 'hui-dialog-edit-card',
+            getRootNode: () => ({ host: null }),
+          },
+        }),
       })
     ).toBe(false);
-    expect(isGeneralCardPickerPreview({})).toBe(false);
+    expect(isCardPickerPreview({ preview: true })).toBe(false);
   });
 
   it('uses a left layout only while rendering a picker preview', () => {

--- a/tests/card-picker.test.js
+++ b/tests/card-picker.test.js
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   createEntitySuggestion,
+  createPreviewConfig,
+  isGeneralCardPickerPreview,
   isTimelineEntitySupported,
+  selectPreviewEntities,
 } from '../src/card-picker.js';
 
 const createHass = (...entityIds) => ({
@@ -59,5 +62,94 @@ describe('Timeline Card entity suggestions', () => {
     const hass = createHass(entityId);
 
     expect(isTimelineEntitySupported(hass, entityId)).toBe(true);
+  });
+});
+
+describe('Timeline Card picker preview', () => {
+  it('selects up to three unique supported entities in HA priority order', () => {
+    const hass = createHass(
+      'button.restart',
+      'binary_sensor.front_door',
+      'sensor.temperature',
+      'person.tobi',
+      'light.kitchen'
+    );
+
+    expect(
+      selectPreviewEntities(
+        hass,
+        [
+          'button.restart',
+          'binary_sensor.front_door',
+          'sensor.temperature',
+          'binary_sensor.front_door',
+        ],
+        ['person.tobi', 'light.kitchen']
+      )
+    ).toEqual([
+      'binary_sensor.front_door',
+      'sensor.temperature',
+      'person.tobi',
+    ]);
+  });
+
+  it('falls back to visible Home Assistant states', () => {
+    const hass = createHass(
+      'button.restart',
+      'sensor.temperature',
+      'binary_sensor.front_door'
+    );
+    hass.entities = {
+      'sensor.temperature': { hidden: true },
+      'binary_sensor.front_door': { hidden: false },
+    };
+
+    expect(selectPreviewEntities(hass, [], [])).toEqual([
+      'binary_sensor.front_door',
+    ]);
+  });
+
+  it('creates a valid stub config without a custom card type', () => {
+    const hass = createHass('sensor.temperature', 'binary_sensor.front_door');
+
+    expect(
+      createPreviewConfig(
+        hass,
+        ['sensor.temperature'],
+        ['binary_sensor.front_door']
+      )
+    ).toEqual({
+      title: 'Timeline',
+      hours: 6,
+      limit: 10,
+      relative_time: true,
+      show_names: true,
+      show_states: true,
+      show_icons: true,
+      entities: [
+        { entity: 'sensor.temperature' },
+        { entity: 'binary_sensor.front_door' },
+      ],
+    });
+  });
+
+  it('returns a valid empty fallback when no suitable entity exists', () => {
+    const hass = createHass('button.restart');
+
+    expect(createPreviewConfig(hass, [], []).entities).toEqual([]);
+  });
+
+  it('detects only the general card picker shadow-root context', () => {
+    expect(
+      isGeneralCardPickerPreview({
+        getRootNode: () => ({ host: { localName: 'hui-card-picker' } }),
+      })
+    ).toBe(true);
+    expect(
+      isGeneralCardPickerPreview({
+        getRootNode: () => ({ host: { localName: 'hui-card' } }),
+      })
+    ).toBe(false);
+    expect(isGeneralCardPickerPreview({})).toBe(false);
   });
 });

--- a/tests/card-picker.test.js
+++ b/tests/card-picker.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createEntitySuggestion,
   createPreviewConfig,
+  getEffectiveTimelineLayout,
   isGeneralCardPickerPreview,
   isTimelineEntitySupported,
   selectPreviewEntities,
@@ -151,5 +152,12 @@ describe('Timeline Card picker preview', () => {
       })
     ).toBe(false);
     expect(isGeneralCardPickerPreview({})).toBe(false);
+  });
+
+  it('uses a left layout only while rendering a picker preview', () => {
+    expect(getEffectiveTimelineLayout('center', true)).toBe('left');
+    expect(getEffectiveTimelineLayout('right', true)).toBe('left');
+    expect(getEffectiveTimelineLayout('center', false)).toBe('center');
+    expect(getEffectiveTimelineLayout('right', false)).toBe('right');
   });
 });

--- a/tests/history-fetch.test.js
+++ b/tests/history-fetch.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchHistory } from '../src/history-fetch.js';
+
+describe('fetchHistory', () => {
+  it('does not call the history API without entities', async () => {
+    const hass = { callApi: vi.fn() };
+
+    const result = await fetchHistory(hass, [], 6);
+
+    expect(hass.callApi).not.toHaveBeenCalled();
+    expect(result.data).toEqual([]);
+    expect(result.start).toBeInstanceOf(Date);
+  });
+});

--- a/tests/live-subscription.test.js
+++ b/tests/live-subscription.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createLiveSubscription } from '../src/live-subscription.js';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('live event subscription lifecycle', () => {
+  it('unsubscribes exactly once when stopped after setup', async () => {
+    const unsubscribe = vi.fn();
+    const connection = {
+      subscribeEvents: vi.fn().mockResolvedValue(unsubscribe),
+    };
+    const subscription = createLiveSubscription(connection, vi.fn());
+
+    await subscription.ready;
+    subscription.stop();
+    subscription.stop();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes exactly once when stopped before setup resolves', async () => {
+    const pending = deferred();
+    const unsubscribe = vi.fn();
+    const connection = {
+      subscribeEvents: vi.fn().mockReturnValue(pending.promise),
+    };
+    const subscription = createLiveSubscription(connection, vi.fn());
+
+    const stopped = subscription.stop();
+    pending.resolve(unsubscribe);
+    await stopped;
+    await subscription.ready;
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles a rejected asynchronous unsubscribe', async () => {
+    const unsubscribe = vi
+      .fn()
+      .mockRejectedValue(new Error('unsubscribe failed'));
+    const connection = {
+      subscribeEvents: vi.fn().mockResolvedValue(unsubscribe),
+    };
+    const subscription = createLiveSubscription(connection, vi.fn());
+
+    await subscription.ready;
+
+    await expect(subscription.stop()).resolves.toBeUndefined();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes subscription setup failures through ready', async () => {
+    const connection = {
+      subscribeEvents: vi.fn(() => {
+        throw new Error('subscribe failed');
+      }),
+    };
+    const subscription = createLiveSubscription(connection, vi.fn());
+
+    await expect(subscription.ready).rejects.toThrow('subscribe failed');
+    await expect(subscription.stop()).resolves.toBeUndefined();
+  });
+});

--- a/tests/preview-items.test.js
+++ b/tests/preview-items.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { createCurrentStatePreview } from '../src/preview-items.js';
+
+const i18n = {
+  getLocalizedState: (_entityId, state) => state,
+};
+
+describe('current-state picker preview', () => {
+  it('builds timeline items locally without a history response', () => {
+    const entities = [
+      { entity: 'sensor.temperature' },
+      { entity: 'binary_sensor.front_door' },
+    ];
+    const hass = {
+      states: {
+        'sensor.temperature': {
+          entity_id: 'sensor.temperature',
+          state: '21.5',
+          attributes: {
+            friendly_name: 'Temperature',
+            unit_of_measurement: '°C',
+          },
+          last_changed: '2026-09-03T18:00:00Z',
+        },
+        'binary_sensor.front_door': {
+          entity_id: 'binary_sensor.front_door',
+          state: 'on',
+          attributes: { friendly_name: 'Front door' },
+          last_changed: '2026-09-03T19:00:00Z',
+        },
+      },
+    };
+
+    const items = createCurrentStatePreview(hass, entities, i18n, 10, {});
+
+    expect(items.map(({ id }) => id)).toEqual([
+      'binary_sensor.front_door',
+      'sensor.temperature',
+    ]);
+    expect(items[1].state).toBe('21.5 °C');
+  });
+
+  it('ignores missing states and respects the configured limit', () => {
+    const entities = [
+      { entity: 'sensor.one' },
+      { entity: 'sensor.missing' },
+      { entity: 'sensor.two' },
+    ];
+    const hass = {
+      states: {
+        'sensor.one': {
+          entity_id: 'sensor.one',
+          state: '1',
+          attributes: {},
+          last_changed: '2026-09-03T18:00:00Z',
+        },
+        'sensor.two': {
+          entity_id: 'sensor.two',
+          state: '2',
+          attributes: {},
+          last_changed: '2026-09-03T19:00:00Z',
+        },
+      },
+    };
+
+    expect(createCurrentStatePreview(hass, entities, i18n, 1, {})).toHaveLength(
+      1
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- enable the live Timeline Card preview in Home Assistant's general card picker
- populate it with up to three suitable real entities in Home Assistant's priority order
- detect the actual `hui-card-picker` rendering context without persisting preview-only configuration
- render preview entries locally from current states without Recorder or WebSocket traffic
- make preview/normal transitions race-safe so stale History or live events cannot overwrite previews
- harden asynchronous live-subscription setup and cleanup for normal Timeline Card instances
- clean up refresh timers across reconfiguration and skip History calls for empty entity lists

## Dependency

This is a stacked PR based on `feat/entity-suggestions` / PR #68. Its own diff contains only the general picker preview and the lifecycle safety it requires. After PR #68 is merged, this PR can be retargeted to `main`.

## Verification

- 46 tests passed
- ESLint passed
- Prettier passed
- production build passed
- release metadata validation passed for `v1.12.0`
- npm audit reported 0 vulnerabilities
- Chromium test using Home Assistant's exact picker sequence (`setConfig` → `hass` → insertion into the `hui-card-picker` shadow root) confirmed:
  - picker preview: 0 History requests and 0 WebSocket subscriptions
  - normal card: History and WebSocket behavior remains active
  - delayed History and stale live events cannot overwrite preview state
  - switching back to normal restarts History, refresh timer, and subscription
  - reconfiguration leaves no orphan refresh timer
  - every subscription is removed exactly once
  - rejected asynchronous unsubscribe promises cause 0 unhandled rejections
