### PR TITLE
fix: stabilize initial single-sided width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,9 @@
 
 ### Added
 
+- Added a styled browser console banner showing the bundled Timeline Card version
 - Added Timeline Card suggestions with the selected entity to Home Assistant's entity-first card picker
 - Added a compact one-sided live Timeline Card preview to the general card picker using suitable entities from the Home Assistant instance, while keeping recorder-backed history active in card-editor previews
-
-No configuration changes are required.
-
-## v1.11.2
-
-### Added
-
-- Added a styled browser console banner showing the bundled Timeline Card version
 
 ### Fixed
 
@@ -27,7 +20,7 @@ No configuration changes are required.
 
 ### Maintenance
 
-- Synchronized package metadata with `v1.11.2` and added release checks for matching tag, package, lockfile, and changelog versions
+- Synchronized package metadata with `v1.12.0` and added release checks for matching tag, package, lockfile, and changelog versions
 
 No configuration changes are required.
 

--- a/src/single-side-width.js
+++ b/src/single-side-width.js
@@ -1,0 +1,3 @@
+export function measureUntransformedWidth(element) {
+  return element.scrollWidth;
+}

--- a/src/timeline-card.js
+++ b/src/timeline-card.js
@@ -34,6 +34,7 @@ import {
 } from './card-picker.js';
 import { createLiveSubscription } from './live-subscription.js';
 import { createCurrentStatePreview } from './preview-items.js';
+import { measureUntransformedWidth } from './single-side-width.js';
 
 const translations = {
   cs,
@@ -822,7 +823,7 @@ class TimelineCard extends HTMLElement {
         const previousMaxWidth = wrapper.style.maxWidth;
         wrapper.style.maxWidth = 'none';
         naturalWidth = Math.max(
-          Math.ceil(wrapper.getBoundingClientRect().width - lineCol - gap + 8),
+          Math.ceil(measureUntransformedWidth(wrapper) - lineCol - gap + 8),
           0
         );
         wrapper.style.maxWidth = previousMaxWidth;

--- a/tests/single-side-width.test.js
+++ b/tests/single-side-width.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { measureUntransformedWidth } from '../src/single-side-width.js';
+
+describe('single-sided card width measurement', () => {
+  it('uses layout pixels instead of transformed visual pixels', () => {
+    const element = {
+      scrollWidth: 224,
+      getBoundingClientRect: () => ({ width: 168 }),
+    };
+
+    expect(measureUntransformedWidth(element)).toBe(224);
+  });
+});


### PR DESCRIPTION
## Summary

- measure single-sided event widths in untransformed layout pixels
- prevent popup and editor opening animations from freezing a compressed first-render width
- consolidate the unreleased `v1.11.2` changelog section into `v1.12.0`

## Root cause

The initial width calculation used `getBoundingClientRect()`. Ancestor opening transforms such as `scale(0.75)` therefore reduced the measured visual width even though the layout width was already final. Removing a transform does not trigger `ResizeObserver`, so the undersized width remained cached until the card was mounted again.

The calculation now uses `scrollWidth`, which is expressed in untransformed layout pixels, before clamping against the available container width as before.

## Verification

- 49/49 unit tests
- deterministic Chromium opening-transform regression test
- narrow-to-wide resize test
- picker LTR/RTL layout test
- card-editor history/filter regression test
- preview/normal lifecycle and race test
- ESLint and Prettier
- production build
- `v1.12.0` release metadata validation
- production audit: 0 vulnerabilities
- independent review: 0 blockers, 0 medium findings
